### PR TITLE
fix: carousel span buttons (CT-1040) (CT-1039)

### DIFF
--- a/src/components/Card/styled.ts
+++ b/src/components/Card/styled.ts
@@ -2,7 +2,7 @@ import Button from '@/components/Button';
 import Image from '@/components/Image';
 import { styled } from '@/styles';
 
-export const CARD_WIDTH = 248;
+export const CARD_WIDTH = 246;
 
 export const Container = styled('section', {
   display: 'inline-flex',

--- a/src/components/Carousel/styled.ts
+++ b/src/components/Carousel/styled.ts
@@ -4,7 +4,7 @@ import Icon from '@/components/Icon';
 import { styled } from '@/styles';
 
 const BUTTON_SIZE = 42;
-export const CAROUSEL_GUTTER_WIDTH = 14;
+export const CAROUSEL_GUTTER_WIDTH = 12;
 
 export const ButtonContainer = styled('span', {
   position: 'absolute',
@@ -29,10 +29,13 @@ export const ButtonContainer = styled('span', {
     },
 
     [`&:active`]: {
-      boxShadow: ' 0 1px 4px 0 $shadow8, 0 0 4px 0 $shadow4, 0 2px 4px 0 $shadow12, 0 5px 8px 0 $shadow12',
+      boxShadow: '0 1px 4px 0 $shadow8, 0 0 4px 0 $shadow4, 0 2px 4px 0 $shadow12, 0 5px 8px 0 $shadow12',
     },
 
-    [`&:hover ${Icon.Frame}, &:active ${Icon.Frame}`]: {
+    [`
+      &:hover ${Icon.Frame},
+      &:active ${Icon.Frame}
+    `]: {
       color: 'rgba(0,0,0,0.8)',
     },
   },

--- a/src/components/Carousel/styled.ts
+++ b/src/components/Carousel/styled.ts
@@ -4,7 +4,7 @@ import Icon from '@/components/Icon';
 import { styled } from '@/styles';
 
 const BUTTON_SIZE = 42;
-export const CAROUSEL_GUTTER_WIDTH = 12;
+export const CAROUSEL_GUTTER_WIDTH = 14;
 
 export const ButtonContainer = styled('span', {
   position: 'absolute',
@@ -15,12 +15,25 @@ export const ButtonContainer = styled('span', {
     height: BUTTON_SIZE,
     width: BUTTON_SIZE,
     backgroundColor: '$white',
+    color: '$black',
     boxShadow: '0 1px 3px 1px $shadow1, 0 0 0 1px $shadow3, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
 
     [`& ${Icon.Frame}`]: {
       height: '$xxs',
       width: '$xxs',
       color: 'rgba(0,0,0,0.6)',
+    },
+
+    [`&:hover`]: {
+      boxShadow: '0 1px 4px 1px $shadow4, 0 0 0 1px $shadow4, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
+    },
+
+    [`&:active`]: {
+      boxShadow: ' 0 1px 4px 0 $shadow8, 0 0 4px 0 $shadow4, 0 2px 4px 0 $shadow12, 0 5px 8px 0 $shadow12',
+    },
+
+    [`&:hover ${Icon.Frame}, &:active ${Icon.Frame}`]: {
+      color: 'rgba(0,0,0,0.8)',
     },
   },
 

--- a/src/components/Carousel/styled.ts
+++ b/src/components/Carousel/styled.ts
@@ -15,7 +15,7 @@ export const ButtonContainer = styled('span', {
     height: BUTTON_SIZE,
     width: BUTTON_SIZE,
     backgroundColor: '$white',
-    boxShadow: '0 5px 8px -8px $shadow12, 0 2px 4px -3px $shadow12, 0 0 0 1px $shadow3, 0 1px 3px 1px $shadow1',
+    boxShadow: '0 1px 3px 1px $shadow1, 0 0 0 1px $shadow3, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
 
     [`& ${Icon.Frame}`]: {
       height: '$xxs',

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -10,7 +10,7 @@ import { Nullish } from '@/types';
 import { chain } from '@/utils/functional';
 
 import { useTimestamp } from './hooks';
-import { Container, Dialog, Overlay, Spacer, Status, Timestamp } from './styled';
+import { Container, Dialog, Overlay, SessionTime, Spacer, Status } from './styled';
 
 export interface ChatProps extends HeaderProps, FooterProps, React.PropsWithChildren {
   description: string;
@@ -56,7 +56,7 @@ const Chat: React.FC<ChatProps> = ({ hasEnded, title, image, description, startT
         <AutoScrollProvider target={dialogRef}>
           <AssistantInfo name={title} image={image} description={description} />
           <Spacer />
-          {!!timestamp && <Timestamp>{timestamp}</Timestamp>}
+          {!!timestamp && <SessionTime>{timestamp}</SessionTime>}
           {children}
           {hasEnded && <Status>You have ended the chat</Status>}
         </AutoScrollProvider>
@@ -74,5 +74,4 @@ export default Object.assign(memo(Chat), {
   Overlay,
   Spacer,
   Status,
-  Timestamp,
 });

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -1,5 +1,4 @@
 import Footer from '@/components/Footer';
-import Header from '@/components/Header';
 import Prompt from '@/components/Prompt';
 import SystemResponse from '@/components/SystemResponse';
 import UserResponse from '@/components/UserResponse';
@@ -32,10 +31,6 @@ export const Container = styled('article', {
   overflow: 'hidden',
   backgroundColor: '$white',
   boxShadow: '0 2px 48px rgba(19,33,68,0.12), 0 0 0 1px $shadow4',
-
-  [`& ${Header.Container}`]: {
-    ...animationStyles({ distance: -SHIFT_DISTANCE, duration: 300, delay: 300 }),
-  },
 
   [`& ${Footer.Container}`]: {
     ...animationStyles({ duration: 300, delay: 300 }),

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -1,6 +1,7 @@
 import Footer from '@/components/Footer';
 import Prompt from '@/components/Prompt';
 import SystemResponse from '@/components/SystemResponse';
+import Timestamp from '@/components/Timestamp';
 import UserResponse from '@/components/UserResponse';
 import { createTransition, CSS, fadeIn, shift, styled } from '@/styles';
 
@@ -84,7 +85,7 @@ export const Status = styled('div', {
   ...statusStyles,
 });
 
-export const Timestamp = styled('span', {
+export const SessionTime = styled('span', {
   ...statusStyles,
   paddingBottom: '$3',
 });
@@ -135,6 +136,8 @@ export const Dialog = styled('main', {
   `]: {
     marginTop: '$5',
   },
+
+  [`& ${Timestamp.Container}`]: { width: 50 },
 
   [`& ${Status}`]: {
     marginTop: '$3',

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -136,7 +136,7 @@ export const Dialog = styled('main', {
 
   [`
     & ${SystemResponse.Container} + ${UserResponse.Container},
-    & ${UserResponse.Container} + ${SystemResponse.Container}
+    & ${UserResponse.Container} + ${SystemResponse.Controls} + ${SystemResponse.Container}
   `]: {
     marginTop: '$5',
   },

--- a/src/components/SystemResponse/SystemMessage.tsx
+++ b/src/components/SystemResponse/SystemMessage.tsx
@@ -10,7 +10,7 @@ import Message from '@/components/Message';
 import Timestamp from '@/components/Timestamp';
 
 import { MessageType } from './constants';
-import { Container, List } from './styled';
+import { Container, Controls, List } from './styled';
 import { MessageProps } from './types';
 
 export interface SystemMessageProps {
@@ -26,7 +26,7 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ image, timestamp, message
 
   return (
     <>
-      <span ref={controlsRef} />
+      <Controls ref={controlsRef} />
       <Container ref={containerRef} withImage={withImage} scrollable={message.type === MessageType.CAROUSEL}>
         <Avatar image={image} />
         <List>

--- a/src/components/SystemResponse/index.tsx
+++ b/src/components/SystemResponse/index.tsx
@@ -8,7 +8,7 @@ import { chain } from '@/utils/functional';
 import { MessageType } from './constants';
 import { useAnimatedMessages } from './hooks';
 import Indicator from './Indicator';
-import { Actions, Container, List } from './styled';
+import { Actions, Container, Controls, List } from './styled';
 import SystemMessage from './SystemMessage';
 import { MessageProps } from './types';
 
@@ -84,6 +84,7 @@ export default Object.assign(SystemResponse, {
   Message: MessageType,
 
   Container,
+  Controls,
   List,
   Actions,
   Indicator,

--- a/src/components/SystemResponse/styled.ts
+++ b/src/components/SystemResponse/styled.ts
@@ -21,6 +21,10 @@ export const Actions = styled('div', {
   },
 });
 
+export const Controls = styled('span', {
+  position: 'relative',
+});
+
 export const Container = styled('div', {
   display: 'flex',
 

--- a/src/components/SystemResponse/styled.ts
+++ b/src/components/SystemResponse/styled.ts
@@ -64,12 +64,6 @@ export const Container = styled('div', {
         [`&::-webkit-scrollbar`]: {
           display: 'none',
         },
-
-        [`& ${Timestamp.Container}`]: {
-          // this is to ensure that the last carousel card is aligned
-          // with preceding messages when fully scrolled
-          marginRight: '2.5px',
-        },
       },
     },
     center: {

--- a/src/components/SystemResponse/styled.ts
+++ b/src/components/SystemResponse/styled.ts
@@ -7,8 +7,8 @@ import { styled } from '@/styles';
 export const Actions = styled('div', {
   display: 'flex',
   flexWrap: 'wrap',
-  marginBottom: '$5',
-  padding: '0 $5 0 34px',
+  marginBottom: 8,
+  padding: '0 $5 0 54px',
 
   [`& ${Button.Container}`]: {
     height: 'unset',

--- a/src/components/Timestamp/styled.ts
+++ b/src/components/Timestamp/styled.ts
@@ -5,7 +5,6 @@ const Container = styled('div', {
   color: '$darkGrey',
   whiteSpace: 'nowrap',
   flexShrink: 0,
-  width: 50,
 });
 
 export default Container;

--- a/src/components/Timestamp/styled.ts
+++ b/src/components/Timestamp/styled.ts
@@ -1,9 +1,11 @@
 import { styled } from '@/styles';
 
-const Container = styled('span', {
+const Container = styled('div', {
   typo: { size: 12, height: '17px' },
   color: '$darkGrey',
   whiteSpace: 'nowrap',
+  flexShrink: 0,
+  width: 50,
 });
 
 export default Container;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1040, CT-1039, CT-1041**

### Brief description. What is this change?
Because we added a new `span` to `SystemMessage`, this was always going to fail:
https://github.com/voiceflow/react-chat/blob/562c937bcdfd40ca1be84b1f1a54904a79cefb14/src/components/Chat/styled.ts#L140-L143
There is now a `span` in between them. I just accounted for it.

The carousel buttons are in the wrong place because they are position absolute and not relative to anything.

I REALLY wish there was some better way to do the controls, because I believe this just pollutes the dom with these spans that we never use. But I've tried for over 2 hours with some kind of potential hack CSS solution and nothing has worked. I give up.
![Screen Shot 2022-09-30 at 12 23 14 AM](https://user-images.githubusercontent.com/5643574/193190202-5c78512c-9173-4b3b-bb84-241c9716996b.png)


