### PR TITLE
fix: public endpoint (CT-1046)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,10 @@ npm install @voiceflow/react-chat
 ```ts
 interface Option {
   /**
-   * the API key for your project
+   * the ID of your voiceflow project, the project must have `apiPrivacy: public`
+   * find this under integrations tab
    */
-  authorization: string;
-
-  /**
-   * [optional] userID to allow users to continue a session
-   */
-  userID?: string;
-
-  /**
-   * [optional] the version ID of your project (appears in the URL)
-   * can also be 'development' or 'production'
-   */
-  versionID?: string;
+  projectID: string;
 
   /**
    * basic assistant information
@@ -38,6 +28,17 @@ interface Option {
     description: string;
     image: string;
   };
+
+  /**
+   * [optional] userID to allow users to continue a session
+   */
+  userID?: string;
+
+  /**
+   * [optional] the version ID of your project, defaults to 'development'
+   * can be a 'development' or 'production' alias or a specific versionID
+   */
+  versionID?: string;
 }
 ```
 
@@ -81,12 +82,12 @@ You can use a simple JavaScript snippet to add the chat widget to any HTML page.
     <script src="https://unpkg.com/@voiceflow/react-chat/dist/bundle.mjs"></script>
     <script>
       vf.chat.show({
+        projectID: 'XXXXXXX.....',
         assistant: {
           name: 'My Assistant',
           description: "It's your friendly, neighborhood chat assistant!",
           image: 'https://source.unsplash.com/random/72x72',
         },
-        authorization: 'VF.DM.xxx123',
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@stitches/react": "^1.2.8",
-    "@voiceflow/base-types": "^2.67.0",
-    "@voiceflow/sdk-runtime": "1.2.1",
-    "@voiceflow/slate-serializer": "1.2.0",
+    "@voiceflow/base-types": "^2.69.0",
+    "@voiceflow/sdk-runtime": "1.3.1",
+    "@voiceflow/slate-serializer": "1.2.2",
     "chroma-js": "^2.4.2",
     "csstype": "^3.1.0",
     "cuid": "^2.1.8",

--- a/src/hooks/useRuntime.ts
+++ b/src/hooks/useRuntime.ts
@@ -42,7 +42,7 @@ interface CarouselTrace {
 
 export interface RuntimeOptions extends SetOptional<VoiceflowRuntimeOptions<RuntimeContext>, 'url'> {
   userID?: string | undefined;
-  versionID: string;
+  versionID?: string | undefined;
   messageDelay?: number | undefined;
 }
 
@@ -56,9 +56,9 @@ export const useRuntime = ({ url = RUNTIME_URL, versionID, userID, messageDelay 
   const [turns, setTurns] = useState<TurnProps[]>([]);
   const sessionID = useMemo(() => (userID ? encodeURIComponent(userID) : cuid()), []);
 
-  const runtime = useMemo(() => new VoiceflowRuntime<RuntimeContext>({ ...options, url }), [options.authorization]);
+  const runtime = useMemo(() => new VoiceflowRuntime<RuntimeContext>({ ...options, url }), [options.verify]);
   const interact = async (action: RuntimeAction): Promise<void> => {
-    const context = await runtime.interact(createContext(), { versionID, sessionID, action });
+    const context = await runtime.interact(createContext(), { sessionID, action, ...(versionID ? { versionID } : {}) });
 
     setTurns((prev) => [
       ...prev,

--- a/src/views/ChatWidget/ChatWidget.story.tsx
+++ b/src/views/ChatWidget/ChatWidget.story.tsx
@@ -6,8 +6,7 @@ export default {
   title: 'Views/ChatWidget',
   component: ChatWidget,
   args: {
-    versionID: '',
-    authorization: '',
+    projectID: '',
     assistant: {
       name: 'Assistant Name',
       image: 'https://source.unsplash.com/random/72x72',

--- a/src/views/ChatWidget/index.tsx
+++ b/src/views/ChatWidget/index.tsx
@@ -13,7 +13,8 @@ interface Session {
   startTime: Date;
 }
 
-export interface ChatWidgetProps extends RuntimeOptions {
+export interface ChatWidgetProps extends Omit<RuntimeOptions, 'verify'> {
+  projectID: string;
   assistant: {
     name: string;
     description: string;
@@ -22,11 +23,11 @@ export interface ChatWidgetProps extends RuntimeOptions {
   messageDelay?: number;
 }
 
-const ChatWidget: React.FC<ChatWidgetProps> = ({ assistant, userID, versionID, authorization, messageDelay }) => {
+const ChatWidget: React.FC<ChatWidgetProps> = ({ assistant, userID, versionID, projectID, messageDelay }) => {
   const [isOpen, setOpen] = useState(false);
   const [hasEnded, setEnded] = useState(false);
   const [session, setSession] = useState<Session | null>(null);
-  const runtime = useRuntime({ versionID, authorization, messageDelay, userID });
+  const runtime = useRuntime({ versionID, verify: { projectID }, messageDelay, userID });
   const hasAnimated = useRef<Record<string, true>>({});
 
   const handleMinimize = (): void => setOpen(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,10 +3762,10 @@
     c8 "^7.12.0"
     vitest "0.23.1"
 
-"@voiceflow/base-types@^2.67.0":
-  version "2.68.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.68.1.tgz#4e722d551fa0d451561e15d930fb821b96427ed4"
-  integrity sha512-bs/+N307PwsZlPo3gI6pk3s3lQ739DbRWQ0MmaYpa9NqQDu3t6powtv5FendyE67zF10HRTvDRAoVys152ftiA==
+"@voiceflow/base-types@^2.69.0":
+  version "2.69.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.69.0.tgz#dcac1f5ec50e1d8934a94a22d2772c9cf1232701"
+  integrity sha512-MG8rNgK+kep1E8doEmyhUUv+1pm58BYNKx6dlMpqm/sZQqvzv51G2ouZcCYgKIfkYog6ivTqJtVrNIyGmm56Tw==
   dependencies:
     "@voiceflow/common" "^8.1.5"
     slate "0.73.0"
@@ -3836,19 +3836,19 @@
   resolved "https://registry.yarnpkg.com/@voiceflow/prettier-config/-/prettier-config-1.2.1.tgz#906bc852bcd8b2586fa62e4635392a0bea1fdb59"
   integrity sha512-J7wnJCwRWSNX33Ji2eLeBxtwXplAKIk9/aOfrHVfKmYrLHqXvOcrl2/7xa37jqnuTl8vw3+UsfFo3sMDY6weTg==
 
-"@voiceflow/sdk-runtime@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/sdk-runtime/-/sdk-runtime-1.2.1.tgz#19e0b439acd5c6a7f38a14bbd89c26eee2536c51"
-  integrity sha512-WggM6WedOZm031cnLDt4NTiY79Vvz5uMz4tDKkRKwwvOCD8kKzWXYNHhSZAc9wkmek2G64p+xXqs8TN5HXL4fw==
+"@voiceflow/sdk-runtime@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/sdk-runtime/-/sdk-runtime-1.3.1.tgz#591392cf96f9ab8c715cbd2e1935c61dd3e0b68d"
+  integrity sha512-Zgoeptd5Sy33Z4KbwuH/ciXfAQiO0W3kcfPm36Sn8EfVqphQ/gTdkGGy9KJ94Ct6cUNnWC9W8k7hnglYuMaYSg==
   dependencies:
     http-errors "^2.0.0"
 
-"@voiceflow/slate-serializer@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/slate-serializer/-/slate-serializer-1.2.0.tgz#9da1da576b65b9fa0259e67501f701980f52eef2"
-  integrity sha512-kmAWNA1ob/1wXbJ3ahebAtWsetkW/o8P/UFUhf0eslov1/fPTh4zd3EZHZY6XXZodrVNeikq3s10QklYw6yXqA==
+"@voiceflow/slate-serializer@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/slate-serializer/-/slate-serializer-1.2.2.tgz#69711c6581bf33b53c47bc42699c4c87a3bd8bf1"
+  integrity sha512-idX3YyQ9dvhx3U6dPZfMFvC/fw9AiUxCsVSoGGi7HHLm5afbKyA0WMmhABqvIsbKucQ1GwrkOR9Bgpch/1psow==
   dependencies:
-    csstype "3.1.1"
+    csstype "^3.0.9"
 
 "@voiceflow/tsconfig@1.4.8":
   version "1.4.8"
@@ -6231,11 +6231,6 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-csstype@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
-  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
-
 csstype@^2.5.7:
   version "2.6.20"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.20.tgz#9229c65ea0b260cf4d3d997cb06288e36a8d6dda"
@@ -6245,6 +6240,11 @@ csstype@^3.0.2, csstype@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
+csstype@^3.0.9:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
+  integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
 cuid@^2.1.8:
   version "2.1.8"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1046**

### Brief description. What is this change?
This PR depended on this part of `sdk-runtime` being merged: https://github.com/voiceflow/adapters/pull/41

While the SDK can accept either an API key or projectID under the `verify` option - we only ever want to expose the `projectID` option - which is why I overrode the type. No one on the frontend should ever be using the API key version with access to underlying logging and debugging methods.
