### PR TITLE
fix: move carousel button to separate component

### DIFF
--- a/src/components/Carousel/CarouselButton.tsx
+++ b/src/components/Carousel/CarouselButton.tsx
@@ -1,0 +1,28 @@
+import { forwardRef } from 'react';
+
+import Icon from '@/components/Icon';
+
+import { ButtonContainer } from './styled';
+
+export interface CarouselButtonProps {
+  onClick?: VoidFunction;
+  alignment: 'left' | 'right';
+  visible: boolean;
+  containerEl: HTMLElement;
+}
+
+const CarouselButton = forwardRef<HTMLElement, CarouselButtonProps>(({ onClick, alignment, visible, containerEl }, ref) => (
+  <ButtonContainer
+    ref={ref}
+    alignment={alignment}
+    visible={visible}
+    css={{
+      transform: `translateY(calc(${containerEl.clientHeight / 2}px - 50%))`,
+    }}
+    onClick={onClick}
+  >
+    <Icon svg="largeArrowLeft" />
+  </ButtonContainer>
+));
+
+export default CarouselButton;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,7 +1,6 @@
 import { RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
-import Bubble from '@/components/Bubble';
 import Card, { CardProps } from '@/components/Card';
 
 import CarouselButton from './CarouselButton';

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -4,9 +4,10 @@ import { createPortal } from 'react-dom';
 import Bubble from '@/components/Bubble';
 import Card, { CardProps } from '@/components/Card';
 
+import CarouselButton from './CarouselButton';
 import { CARD_WITH_GUTTER_WIDTH } from './constants';
 import { useScrollObserver, useScrollTo } from './hooks';
-import { ButtonContainer, Container } from './styled';
+import { Container } from './styled';
 
 export interface CarouselProps {
   cards: CardProps[];
@@ -33,26 +34,14 @@ const Carousel: React.FC<CarouselProps> = ({ cards, containerRef, controlsRef })
       {showControls &&
         createPortal(
           <>
-            <ButtonContainer
+            <CarouselButton
               ref={previousButtonRef}
               alignment="left"
               visible={showPreviousButton}
-              css={{
-                transform: `translateY(calc(${containerEl.clientHeight / 2}px - 50%))`,
-              }}
-            >
-              <Bubble svg="largeArrowLeft" onClick={scrollToPrevious} />
-            </ButtonContainer>
-            <ButtonContainer
-              ref={nextButtonRef}
-              alignment="right"
-              visible={showNextButton}
-              css={{
-                transform: `translateY(calc(${containerEl.clientHeight / 2}px - 50%))`,
-              }}
-            >
-              <Bubble svg="largeArrowLeft" onClick={scrollToNext} />
-            </ButtonContainer>
+              containerEl={containerEl}
+              onClick={scrollToPrevious}
+            />
+            <CarouselButton ref={nextButtonRef} alignment="right" visible={showNextButton} containerEl={containerEl} onClick={scrollToNext} />
           </>,
           controlsEl
         )}
@@ -62,5 +51,4 @@ const Carousel: React.FC<CarouselProps> = ({ cards, containerRef, controlsRef })
 
 export default Object.assign(Carousel, {
   Container,
-  ButtonContainer,
 });

--- a/src/components/Carousel/styled.ts
+++ b/src/components/Carousel/styled.ts
@@ -1,4 +1,3 @@
-import Bubble from '@/components/Bubble';
 import Card from '@/components/Card';
 import Icon from '@/components/Icon';
 import { styled } from '@/styles';
@@ -9,37 +8,41 @@ export const CAROUSEL_GUTTER_WIDTH = 12;
 export const ButtonContainer = styled('span', {
   position: 'absolute',
   zIndex: 1,
-  trans: ['opacity'],
 
-  [`& ${Bubble.Container}`]: {
-    height: BUTTON_SIZE,
-    width: BUTTON_SIZE,
-    backgroundColor: '$white',
-    color: '$black',
-    boxShadow: '0 1px 3px 1px $shadow1, 0 0 0 1px $shadow3, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
-    border: 'none',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '$round',
+  trans: ['background-color', 'box-shadow', 'opacity'],
 
-    [`& ${Icon.Frame}`]: {
-      height: '$xxs',
-      width: '$xxs',
-      color: 'rgba(0,0,0,0.6)',
-      trans: ['color'],
-    },
+  height: BUTTON_SIZE,
+  width: BUTTON_SIZE,
+  cursor: 'pointer',
+  backgroundColor: '$white',
+  color: '$black',
+  boxShadow: '0 1px 3px 1px $shadow1, 0 0 0 1px $shadow3, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
+  border: 'none',
 
-    [`&:hover`]: {
-      boxShadow: '0 1px 4px 1px $shadow4, 0 0 0 1px $shadow4, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
-    },
+  [`& ${Icon.Frame}`]: {
+    height: '$xxs',
+    width: '$xxs',
+    color: 'rgba(0,0,0,0.6)',
+    trans: ['color'],
+  },
 
-    [`&:active`]: {
-      boxShadow: '0 1px 4px 1px $shadow8, 0 0 0 1px $shadow4, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
-    },
+  [`&:hover`]: {
+    boxShadow: '0 1px 4px 1px $shadow4, 0 0 0 1px $shadow4, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
+  },
 
-    [`
+  [`&:active`]: {
+    boxShadow: '0 1px 4px 1px $shadow8, 0 0 0 1px $shadow4, 0 2px 4px -3px $shadow12, 0 5px 8px -8px $shadow12',
+  },
+
+  [`
       &:hover ${Icon.Frame},
       &:active ${Icon.Frame}
     `]: {
-      color: 'rgba(0,0,0,0.8)',
-    },
+    color: 'rgba(0,0,0,0.8)',
   },
 
   variants: {
@@ -60,7 +63,7 @@ export const ButtonContainer = styled('span', {
       right: {
         right: 70 - BUTTON_SIZE / 2,
 
-        [`& ${Bubble.Container} ${Icon.Frame}`]: {
+        [`& ${Icon.Frame}`]: {
           transform: 'scaleX(-1)',
         },
       },


### PR DESCRIPTION
the carousel button practically overrides every attribute of Bubble

There's been multiple instances where we applied some style to Bubble.Container and it had some adverse effect either on the carousel button or other buttons.

I think it's better to leave them distinct for now. We also don't need the wrapper anymore which is nice.