### PR TITLE
fix: remove working dir from non-run steps (IN-000)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        working-directory: ./packages/react-chat
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
@@ -18,9 +17,8 @@ jobs:
           yarn install
           yarn build:docs
       - name: Deploy
-        working-directory: ./packages/react-chat
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           branch: docs
-          folder: docs
+          folder: ./packages/react-chat/docs
           clean: true


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

Fixes failing Github Actions workflow. It was failing every commit due to an invalid config

### Implementation details. How do you make this change?

The `working-directory` parameter is only valid for `run` steps. For other steps, the working dir needs to be specified in a different way depending on the purpose of the command.

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

