### PR TITLE
fix: unique bundle file (CT-000)

### DIFF
--- a/packages/react-chat/vite.config.ts
+++ b/packages/react-chat/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import cuid from 'cuid';
 import path from 'path';
 import { defineConfig, PluginOption } from 'vite';
 import fonts from 'vite-plugin-fonts';
@@ -35,7 +36,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'index.html'),
       name: 'voiceflow-chat',
-      fileName: 'bundle',
+      fileName: cuid(),
       formats: ['es'],
     },
   },


### PR DESCRIPTION
S3/Cloudfront seems to be caching the files, since they are all the same name: `index.html` and `bundle.mjs`
This makes it hard to propagate updates/bug fixes.

The problem with this is that after publication to the CDN the older file is no longer available and could lead to a "chunk not found" error that we've seen before on creator-app.

Ideally, I'd like to find a way to force new versions when released.
<img width="1273" alt="Screen Shot 2022-11-01 at 5 54 00 PM" src="https://user-images.githubusercontent.com/5643574/199349148-3736eea3-d152-4528-b61a-e53fc073ee72.png">

Even if the JS file is updated, the `index.html` that the iframe calls is still cached, and referencing an older JS file.
I vague remember methods to use a query param `?dsdsd.....` to overwrite it. But that defeats the purpose of a CDN if we are going to generate a new query every time.

https://github.com/voiceflow/react-chat/blob/017e7c3cca9e6e1235233075ea5716a4708f7df1/packages/widget/.env.production#L3

Maybe the best way is to pass in a build key env var.
That still won't stop the code/pasted code snippet from being cached. 

It seems to cache for up to 24 hours:
https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-serving-outdated-content-s3/