### PR TITLE
feat: use context instead of hook (CT-1156)

### DIFF
--- a/packages/react-chat/src/components/Card/index.tsx
+++ b/packages/react-chat/src/components/Card/index.tsx
@@ -1,6 +1,9 @@
-import type { RuntimeAction, SendMessage } from '@/common';
+import { useContext } from 'react';
+
+import type { RuntimeAction } from '@/common';
 import Button from '@/components/Button';
 import Image from '@/components/Image';
+import { RuntimeContext } from '@/contexts';
 
 import { Container, Content, Description, Header } from './styled';
 
@@ -14,23 +17,26 @@ export interface CardProps {
   description: string;
   image?: string | undefined | null;
   actions?: CardActionProps[] | undefined;
-  send?: SendMessage | undefined;
 }
 
-const Card: React.FC<CardProps> = ({ title, send, description, image, actions = [] }) => (
-  <Container>
-    {!!image && <Image image={image} rounded={false} />}
-    <Content>
-      <Header>{title}</Header>
-      <Description>{description}</Description>
-      {actions.map(({ name, request }, index) => (
-        <Button onClick={() => send?.(name, request)} key={index}>
-          {name}
-        </Button>
-      ))}
-    </Content>
-  </Container>
-);
+const Card: React.FC<CardProps> = ({ title, description, image, actions = [] }) => {
+  const runtime = useContext(RuntimeContext);
+
+  return (
+    <Container>
+      {!!image && <Image image={image} rounded={false} />}
+      <Content>
+        <Header>{title}</Header>
+        <Description>{description}</Description>
+        {actions.map(({ name, request }, index) => (
+          <Button onClick={() => runtime?.send(name, request)} key={index}>
+            {name}
+          </Button>
+        ))}
+      </Content>
+    </Container>
+  );
+};
 
 export default Object.assign(Card, {
   Container,

--- a/packages/react-chat/src/components/Carousel/index.tsx
+++ b/packages/react-chat/src/components/Carousel/index.tsx
@@ -10,13 +10,12 @@ import { useScrollObserver, useScrollTo } from './hooks';
 import { Container } from './styled';
 
 export interface CarouselProps {
-  send?: SendMessage | undefined;
   cards: CardProps[];
   containerRef?: RefObject<HTMLDivElement>;
   controlsRef?: RefObject<HTMLSpanElement>;
 }
 
-const Carousel: React.FC<CarouselProps> = ({ cards, containerRef, controlsRef, send }) => {
+const Carousel: React.FC<CarouselProps> = ({ cards, containerRef, controlsRef }) => {
   const { previousButtonRef, nextButtonRef, showPreviousButton, showNextButton } = useScrollObserver(containerRef, controlsRef, cards);
   const containerEl = containerRef?.current;
   const controlsEl = controlsRef?.current;
@@ -29,7 +28,7 @@ const Carousel: React.FC<CarouselProps> = ({ cards, containerRef, controlsRef, s
     <>
       <Container>
         {cards.map((card, index) => (
-          <Card send={send} {...card} key={index} />
+          <Card {...card} key={index} />
         ))}
       </Container>
       {showControls &&

--- a/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
@@ -1,15 +1,16 @@
 import { serializeToJSX } from '@voiceflow/slate-serializer/jsx';
-import { useRef } from 'react';
+import { useContext, useRef } from 'react';
 import * as R from 'remeda';
 import { match } from 'ts-pattern';
 
-import { SendMessage } from '@/common';
+import { SendMessage, SessionStatus } from '@/common';
 import Avatar from '@/components/Avatar';
 import Card from '@/components/Card';
 import Carousel from '@/components/Carousel';
 import Image from '@/components/Image';
 import Message from '@/components/Message';
 import Timestamp from '@/components/Timestamp';
+import { RuntimeContext } from '@/contexts';
 
 import { MessageType } from './constants';
 import EndState from './state/end';
@@ -17,20 +18,20 @@ import { Container, Controls, List } from './styled';
 import { MessageProps } from './types';
 
 export interface SystemMessageProps {
-  send?: SendMessage | undefined;
   avatar: string;
   timestamp: number;
   message: MessageProps;
   withImage: boolean;
-  onEnd?: VoidFunction | undefined;
 }
 
-const SystemMessage: React.FC<SystemMessageProps> = ({ send, avatar, timestamp, message, withImage, onEnd }) => {
+const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, timestamp, message, withImage }) => {
+  const runtime = useContext(RuntimeContext);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<HTMLSpanElement>(null);
 
   if (message.type === MessageType.END) {
-    return <EndState onEnd={onEnd} />;
+    return <EndState onEnd={() => runtime?.setStatus(SessionStatus.ENDED)} />;
   }
 
   return (
@@ -42,9 +43,9 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ send, avatar, timestamp, 
           {match(message)
             .with({ type: MessageType.TEXT }, ({ text }) => <Message from="system">{typeof text === 'string' ? text : serializeToJSX(text)}</Message>)
             .with({ type: MessageType.IMAGE }, ({ url }) => <Image image={url} />)
-            .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} send={send} />)
+            .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} />)
             .with({ type: MessageType.CAROUSEL }, (props) => (
-              <Carousel {...R.omit(props, ['type'])} send={send} containerRef={containerRef} controlsRef={controlsRef} />
+              <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
             ))
             .otherwise(() => null)}
         </List>

--- a/packages/react-chat/src/components/SystemResponse/index.tsx
+++ b/packages/react-chat/src/components/SystemResponse/index.tsx
@@ -1,5 +1,8 @@
+import { useContext } from 'react';
+
 import type { RuntimeAction, SendMessage } from '@/common';
 import Button from '@/components/Button';
+import { RuntimeContext } from '@/contexts';
 import { useAutoScroll } from '@/hooks';
 
 import { MessageType } from './constants';
@@ -22,11 +25,11 @@ export interface SystemResponseProps {
   messages: MessageProps[];
   actions?: ResponseActionProps[];
   isLast?: boolean;
-  send?: SendMessage;
-  onEnd?: VoidFunction;
 }
 
-const SystemResponse: React.FC<SystemResponseProps> = ({ send, avatar, timestamp, messages, actions = [], isLast, onEnd }) => {
+const SystemResponse: React.FC<SystemResponseProps> = ({ avatar, timestamp, messages, actions = [], isLast }) => {
+  const runtime = useContext(RuntimeContext);
+
   const { showIndicator, visibleMessages, complete } = useAnimatedMessages({
     messages,
     isLast,
@@ -40,20 +43,18 @@ const SystemResponse: React.FC<SystemResponseProps> = ({ send, avatar, timestamp
     <>
       {visibleMessages.map((message, index) => (
         <SystemMessage
-          send={send}
           message={message}
           withImage={!showIndicator && index === visibleMessages.length - 1}
           avatar={avatar}
           timestamp={timestamp}
           key={index}
-          onEnd={onEnd}
         />
       ))}
 
       {isLast && complete && !!actions.length && (
         <Actions>
           {actions.map(({ name, request }, index) => (
-            <Button variant="secondary" onClick={() => send?.(name, request)} key={index}>
+            <Button variant="secondary" onClick={() => runtime?.send(name, request)} key={index}>
               {name}
             </Button>
           ))}

--- a/packages/react-chat/src/contexts/index.ts
+++ b/packages/react-chat/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './AutoScrollContext';
+export * from './RuntimeContext';

--- a/packages/react-chat/src/hooks/index.ts
+++ b/packages/react-chat/src/hooks/index.ts
@@ -1,4 +1,3 @@
 export * from './useAutoScroll';
 export * from './useDidUpdateEffect';
-export * from './useRuntime';
 export * from './useStateRef';


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1156**

### Brief description. What is this change?
I had the sense that we were prop drilling way too hard. instead of `useRuntime` I'm doing a `RuntimeContext` instead.