### PR TITLE
feat: fix line hight (BUG-174)

### DIFF
--- a/packages/react-chat/src/components/AssistantInfo/styled.ts
+++ b/packages/react-chat/src/components/AssistantInfo/styled.ts
@@ -6,7 +6,7 @@ export const Title = styled('h2', {
   ...textOverflowStyles,
   width: '100%',
   margin: 0,
-  typo: { size: 20, weight: '$2', height: '$2' },
+  typo: { size: 20, weight: '$2', height: '$3' },
   color: '$black',
 });
 


### PR DESCRIPTION
This fixes [BUG-174](https://voiceflow.atlassian.net/jira/software/c/projects/CT/boards/13?modal=detail&selectedIssue=BUG-174&assignee=621458878e1bf000692ff209) by increasing the react-chat title's line height.

<img width="317" alt="Screen Shot 2023-02-14 at 15 29 08" src="https://user-images.githubusercontent.com/9748039/218827459-82370612-230d-4f43-b110-f4399f77df8e.PNG">


[BUG-174]: https://voiceflow.atlassian.net/browse/BUG-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ