### PR TITLE
fix: added webchat into closure with iife format (CT-1961)

### DIFF
--- a/packages/widget/vite.config.ts
+++ b/packages/widget/vite.config.ts
@@ -26,7 +26,13 @@ export default defineConfig(({ mode }) => {
         entry: path.resolve(__dirname, 'index.tsx'),
         name: 'voiceflow-chat-iframe',
         fileName: 'bundle',
-        formats: ['es'],
+        formats: ['iife'],
+      },
+      rollupOptions: {
+        output: {
+          extend: true,
+          entryFileNames: 'bundle.mjs',
+        },
       },
     },
     plugins: [react(), ...createPlugins()],


### PR DESCRIPTION
**Fixes or implements CT-1961**

### Brief description. What is this change?
We were having conflicts with global variables. So changed generated file format to `iife` so all the script variables are scoped. We're keeping `.mjs` file extension for retrocompatibility, but it'd be good to have just `bundle.js` in the future.