### PR TITLE
fix: resolve promise on load session (CT-000)

### DIFF
--- a/packages/widget/index.tsx
+++ b/packages/widget/index.tsx
@@ -1,4 +1,5 @@
 import type { ChatConfig } from '@voiceflow/react-chat';
+import { Listeners, PostMessage } from '@voiceflow/react-chat';
 import { createRoot } from 'react-dom/client';
 
 import Widget from './src';
@@ -27,4 +28,8 @@ window.voiceflow.chat.load = async (loadConfig: Partial<ChatConfig>) => {
   const config = sanitizeConfig(loadConfig);
 
   root.render(<Widget {...config} widgetURL={WIDGET_URL!} />);
+
+  return new Promise<void>((resolve) => {
+    Listeners.context.listeners.push({ type: PostMessage.Type.SESSION, action: resolve });
+  });
 };


### PR DESCRIPTION
We need a way to know when the actual `ChatWidget` is ready so that we can call `window.voiceflow.chat.open`
Otherwise, that `open` call will never work.

After this implementation the intended goal is:
```
        window.voiceflow.chat.load({
          url: 'https://general-runtime.development.voiceflow.com',
          verify: { projectID: 'xxx-123-xxx-456' },
          user: {
            name: 'Development User',
          },
        }).then(() => window.voiceflow.chat.open());
```
