### PR TITLE
fix: release monorepo task

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -12,7 +12,7 @@ parameters:
     default: false
 
 orbs:
-  vfcommon: voiceflow/common@0.15.1
+  vfcommon: voiceflow/common@0.39.1
   sonarcloud: sonarsource/sonarcloud@1.0.2
 
 defaults:


### PR DESCRIPTION
### Brief description. What is this change?

- seems like we're using an old container with an incompatible node engine

https://app.circleci.com/pipelines/github/voiceflow/react-chat/857/workflows/f07993d8-c816-4ea6-aa6b-532bc02b992c/jobs/1340/parallel-runs/0/steps/0-110

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test