### PR TITLE
feat: include last user turn in the feedback (CT-2094)

### DIFF
--- a/packages/react-chat/src/components/Feedback/index.tsx
+++ b/packages/react-chat/src/components/Feedback/index.tsx
@@ -13,20 +13,15 @@ export interface FeedbackProps extends React.PropsWithChildren {
    */
   question?: string;
 
-  /**
-   * Message that will be sent with the feedback
-   */
-  aiMessage: string;
-
-  onClick: (feedback: FeedbackName, message: string) => void;
+  onClick: (feedback: FeedbackName) => void;
 }
 
-const Feedback: React.FC<FeedbackProps> = ({ question = 'Was this helpful?', onClick, aiMessage, ...props }) => {
+const Feedback: React.FC<FeedbackProps> = ({ question = 'Was this helpful?', onClick, ...props }) => {
   const [active, setActive] = React.useState<FeedbackName | null>(null);
 
   const handleClick = (feedback: FeedbackName) => {
     if (feedback === active) return;
-    onClick(feedback, aiMessage);
+    onClick(feedback);
     setActive(feedback);
   };
 

--- a/packages/react-chat/src/components/SystemResponse/index.tsx
+++ b/packages/react-chat/src/components/SystemResponse/index.tsx
@@ -1,5 +1,4 @@
-import { serializeToText } from '@voiceflow/slate-serializer/text';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 
 import type { RuntimeAction } from '@/common';
 import Button from '@/components/Button';
@@ -52,7 +51,7 @@ export interface SystemResponseProps {
    * If provided, will display {@link Feedback} component under the last message.
    * @default false
    */
-  feedback?: Omit<FeedbackProps, 'aiMessage'> | undefined;
+  feedback?: FeedbackProps | undefined;
 
   /**
    * Override the rendering of individual messages.
@@ -69,13 +68,6 @@ const SystemResponse: React.FC<SystemResponseProps> = ({ feedback, avatar, times
   });
 
   useAutoScroll([showIndicator, complete, visibleMessages.length]);
-  const aiMessage = useMemo(() => visibleMessages.find(({ ai }) => ai), [visibleMessages]);
-
-  const feedbackProps = useMemo(() => {
-    if (aiMessage?.type !== MessageType.TEXT || !feedback) return undefined;
-
-    return { ...feedback, aiMessage: typeof aiMessage.text === 'string' ? aiMessage.text : serializeToText(aiMessage.text) };
-  }, [aiMessage, feedback]);
 
   if (!messages.length && !actions.length) return null;
 
@@ -85,7 +77,7 @@ const SystemResponse: React.FC<SystemResponseProps> = ({ feedback, avatar, times
         <Message
           message={message}
           withImage={!showIndicator && index === visibleMessages.length - 1}
-          feedback={complete && !showIndicator && index === visibleMessages.length - 1 ? feedbackProps : undefined}
+          feedback={complete && !showIndicator && index === visibleMessages.length - 1 ? feedback : undefined}
           avatar={avatar}
           timestamp={timestamp}
           key={index}

--- a/packages/react-chat/src/views/ChatWindow/index.tsx
+++ b/packages/react-chat/src/views/ChatWindow/index.tsx
@@ -5,8 +5,8 @@ import { match } from 'ts-pattern';
 import { Assistant, ChatConfig, Listeners, PostMessage, SessionOptions, SessionStatus, useTheme } from '@/common';
 import { Chat, SystemResponse, UserResponse } from '@/components';
 import { RuntimeAPIProvider } from '@/contexts';
-import { useRuntime } from '@/hooks';
-import { TurnType } from '@/types';
+import { FeedbackName, useRuntime } from '@/hooks';
+import { TurnType, UserTurnProps } from '@/types';
 
 import { ChatWindowContainer } from './styled';
 import { sendMessage } from './utils';
@@ -44,6 +44,14 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
 
   const theme = useTheme(assistant);
 
+  const getPreviousUserTurn = useCallback(
+    (turnIndex: number): UserTurnProps | null => {
+      const turn = runtime.session.turns[turnIndex - 1];
+      return turn?.type === TurnType.USER ? turn : null;
+    },
+    [runtime.session.turns]
+  );
+
   return (
     <RuntimeAPIProvider {...runtime}>
       <ChatWindowContainer className={theme}>
@@ -71,7 +79,9 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
                   feedback={
                     assistant.feedback
                       ? {
-                          onClick: runtime.feedback,
+                          onClick: (feedback: FeedbackName) => {
+                            runtime.feedback(feedback, props.messages, getPreviousUserTurn(turnIndex));
+                          },
                         }
                       : undefined
                   }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-2094**

### Brief description. What is this change?

 - Send all ai messages in the turn instead of only the first one
 - Send last user turn before the one user is giving feedback 

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?
Did some cleanup to reduce the spread of feedback logic

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

