### PR TITLE
fix: use traces to avoid re-render issues (DX-000)

### DIFF
--- a/packages/react-chat/src/common/types.ts
+++ b/packages/react-chat/src/common/types.ts
@@ -8,7 +8,7 @@ export type { RuntimeAction };
 
 export type SendMessage = (message: string, action: RuntimeAction) => Promise<void>;
 
-export interface RuntimeOptions extends Omit<SDKRuntimeOptions<AuthVerify | PublicVerify>, 'url'> {
+export interface RuntimeOptions<Verify extends AuthVerify | PublicVerify = AuthVerify | PublicVerify> extends Omit<SDKRuntimeOptions<Verify>, 'url'> {
   url?: string | undefined;
   user?:
     | {
@@ -35,6 +35,6 @@ export interface SessionOptions {
 
 export type Assistant = Omit<ChatPublishing & Required<Omit<ChatPublishing, 'launcher'>>, 'selectedIntents'>;
 
-export interface ChatConfig extends RuntimeOptions {
+export interface ChatConfig extends RuntimeOptions<PublicVerify> {
   assistant?: Assistant;
 }

--- a/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
@@ -16,7 +16,7 @@ import EndState from './state/end';
 import { Container, Controls, List } from './styled';
 import { MessageProps } from './types';
 
-export interface SystemMessageProps {
+export interface SystemMessageProps extends React.PropsWithChildren {
   /**
    * An image URL for an avatar to associate this message with.
    */
@@ -30,7 +30,7 @@ export interface SystemMessageProps {
   /**
    * A single message to render with a {@link Message} component.
    */
-  message: MessageProps;
+  message?: MessageProps;
 
   /**
    * If true, renders an avatar next to the message.
@@ -44,28 +44,32 @@ export interface SystemMessageProps {
   feedback?: FeedbackProps | undefined;
 }
 
-const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timestamp, message, withImage }) => {
+const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timestamp, message, withImage, children }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<HTMLSpanElement>(null);
 
-  if (message.type === MessageType.END) {
+  if (message?.type === MessageType.END) {
     return <EndState />;
   }
 
   return (
     <>
       <Controls ref={controlsRef} />
-      <Container ref={containerRef} withImage={withImage} scrollable={message.type === MessageType.CAROUSEL}>
+      <Container ref={containerRef} withImage={withImage} scrollable={message?.type === MessageType.CAROUSEL}>
         <Avatar avatar={avatar} />
         <List>
-          {match(message)
-            .with({ type: MessageType.TEXT }, ({ text }) => <Message from="system">{typeof text === 'string' ? text : serializeToJSX(text)}</Message>)
-            .with({ type: MessageType.IMAGE }, ({ url }) => <Image image={url} />)
-            .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} />)
-            .with({ type: MessageType.CAROUSEL }, (props) => (
-              <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
-            ))
-            .otherwise(() => null)}
+          {message
+            ? match(message)
+                .with({ type: MessageType.TEXT }, ({ text }) => (
+                  <Message from="system">{typeof text === 'string' ? text : serializeToJSX(text)}</Message>
+                ))
+                .with({ type: MessageType.IMAGE }, ({ url }) => <Image image={url} />)
+                .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} />)
+                .with({ type: MessageType.CAROUSEL }, (props) => (
+                  <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
+                ))
+                .otherwise(() => null)
+            : children}
           {feedback && <Feedback {...feedback} />}
         </List>
         <Timestamp value={timestamp} />

--- a/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
@@ -48,7 +48,7 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timesta
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<HTMLSpanElement>(null);
 
-  if (message?.type === MessageType.END) {
+  if (!children && message?.type === MessageType.END) {
     return <EndState />;
   }
 
@@ -58,18 +58,17 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timesta
       <Container ref={containerRef} withImage={withImage} scrollable={message?.type === MessageType.CAROUSEL}>
         <Avatar avatar={avatar} />
         <List>
-          {message
-            ? match(message)
-                .with({ type: MessageType.TEXT }, ({ text }) => (
-                  <Message from="system">{typeof text === 'string' ? text : serializeToJSX(text)}</Message>
-                ))
-                .with({ type: MessageType.IMAGE }, ({ url }) => <Image image={url} />)
-                .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} />)
-                .with({ type: MessageType.CAROUSEL }, (props) => (
-                  <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
-                ))
-                .otherwise(() => null)
-            : children}
+          {children ??
+            match(message)
+              .with({ type: MessageType.TEXT }, ({ text }) => (
+                <Message from="system">{typeof text === 'string' ? text : serializeToJSX(text)}</Message>
+              ))
+              .with({ type: MessageType.IMAGE }, ({ url }) => <Image image={url} />)
+              .with({ type: MessageType.CARD }, (props) => <Card {...R.omit(props, ['type'])} />)
+              .with({ type: MessageType.CAROUSEL }, (props) => (
+                <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
+              ))
+              .otherwise(() => null)}
           {feedback && <Feedback {...feedback} />}
         </List>
         <Timestamp value={timestamp} />

--- a/packages/react-chat/src/components/SystemResponse/types.ts
+++ b/packages/react-chat/src/components/SystemResponse/types.ts
@@ -33,4 +33,9 @@ export interface EndMessage extends BaseMessageProps {
   type: StringifiedEnum<MessageType.END>;
 }
 
-export type MessageProps = TextMessageProps | ImageMessageProps | CardMessageProps | CarouselMessageProps | EndMessage;
+export interface CustomMessage extends BaseMessageProps {
+  type: `custom_${string}`;
+  payload: any;
+}
+
+export type MessageProps = TextMessageProps | ImageMessageProps | CardMessageProps | CarouselMessageProps | EndMessage | CustomMessage;

--- a/packages/react-chat/src/hooks/useRuntime.ts
+++ b/packages/react-chat/src/hooks/useRuntime.ts
@@ -9,7 +9,7 @@ import { RuntimeOptions, SendMessage, SessionOptions, SessionStatus } from '@/co
 import type { MessageProps } from '@/components/SystemResponse';
 import { MessageType } from '@/components/SystemResponse/constants';
 import { RUNTIME_URL } from '@/constants';
-import { RuntimeContext, TRACES } from '@/runtime';
+import { MESSAGE_TRACES, RuntimeContext } from '@/runtime';
 import { TurnProps, TurnType, UserTurnProps } from '@/types';
 import { handleActions } from '@/utils/actions';
 
@@ -77,7 +77,7 @@ export const useRuntime = ({ url = RUNTIME_URL, versionID, verify, user, ...conf
         url,
         traces: [
           ...(config.traces ?? []),
-          ...TRACES,
+          ...MESSAGE_TRACES,
           {
             canHandle: ({ type }) => type === Trace.TraceType.NO_REPLY,
             handle: ({ context }, _trace) => {

--- a/packages/react-chat/src/hooks/useRuntime.ts
+++ b/packages/react-chat/src/hooks/useRuntime.ts
@@ -1,30 +1,19 @@
 import { Trace as BaseTypesTrace } from '@voiceflow/base-types';
-import {
-  ActionType,
-  CardV2TraceComponent,
-  ChoiceTraceComponent,
-  RuntimeAction,
-  TextTraceComponent,
-  Trace,
-  TraceDeclaration,
-  VisualTraceComponent,
-  VoiceflowRuntime,
-} from '@voiceflow/sdk-runtime';
+import { ActionType, RuntimeAction, Trace, TraceDeclaration, VoiceflowRuntime } from '@voiceflow/sdk-runtime';
 import { serializeToText } from '@voiceflow/slate-serializer/text';
 import Bowser from 'bowser';
 import cuid from 'cuid';
 import { useEffect, useMemo, useState } from 'react';
 
 import { RuntimeOptions, SendMessage, SessionOptions, SessionStatus } from '@/common';
-import type { MessageProps, SystemResponseProps } from '@/components/SystemResponse';
+import type { MessageProps } from '@/components/SystemResponse';
 import { MessageType } from '@/components/SystemResponse/constants';
 import { RUNTIME_URL } from '@/constants';
+import { RuntimeContext, TRACES } from '@/runtime';
 import { TurnProps, TurnType, UserTurnProps } from '@/types';
 import { handleActions } from '@/utils/actions';
 
 import { useStateRef } from './useStateRef';
-
-export interface RuntimeContext extends Pick<SystemResponseProps, 'messages' | 'actions'> {}
 
 const createContext = (): RuntimeContext => ({
   messages: [],
@@ -33,6 +22,7 @@ const createContext = (): RuntimeContext => ({
 interface UseRuntimeProps extends RuntimeOptions {
   session: SessionOptions;
   saveSession?: (session: SessionOptions) => void;
+  traces?: TraceDeclaration<RuntimeContext, any>[];
 }
 
 export enum FeedbackName {
@@ -50,7 +40,7 @@ const DEFAULT_RUNTIME_STATE: Required<SessionOptions> = {
 /**
  * A wrapper for the Voiceflow runtime client.
  */
-export const useRuntime = ({ url = RUNTIME_URL, versionID, verify, user, ...config }: UseRuntimeProps) => {
+export const useRuntime = ({ url = RUNTIME_URL, versionID, verify, user, ...config }: UseRuntimeProps, dependencies: any[] = []) => {
   const [indicator, setIndicator] = useState(false);
   const [session, setSession, sessionRef] = useStateRef<Required<SessionOptions>>({ ...DEFAULT_RUNTIME_STATE, ...config.session });
   const [lastInteractionAt, setLastInteractionAt] = useState<number | null>(Date.now());
@@ -80,85 +70,29 @@ export const useRuntime = ({ url = RUNTIME_URL, versionID, verify, user, ...conf
     };
   }, [noReplyTimeout, lastInteractionAt]);
 
-  const runtime = useMemo(() => {
-    const runtime = new VoiceflowRuntime<RuntimeContext>({ verify, url });
+  const runtime = useMemo(
+    () =>
+      new VoiceflowRuntime<RuntimeContext>({
+        verify,
+        url,
+        traces: [
+          ...(config.traces ?? []),
+          ...TRACES,
+          {
+            canHandle: ({ type }) => type === Trace.TraceType.NO_REPLY,
+            handle: ({ context }, _trace) => {
+              const trace = _trace as BaseTypesTrace.NoReplyTrace;
 
-    runtime.registerStep(
-      TextTraceComponent(({ context }, { payload }) => {
-        const { slate, message } = payload;
+              setNoReplyTimeout(trace.payload.timeout * 1000);
+              setLastInteractionAt(Date.now());
 
-        context.messages.push({
-          type: MessageType.TEXT,
-          text: slate?.content || message,
-          delay: payload.delay,
-          ...(payload.ai ? { ai: payload.ai } : {}),
-        });
-        return context;
-      })
-    );
-    runtime.registerStep(
-      VisualTraceComponent(({ context }, { payload: { image } }) => {
-        context.messages.push({ type: MessageType.IMAGE, url: image });
-        return context;
-      })
-    );
-    runtime.registerStep(
-      ChoiceTraceComponent(({ context }, { payload: { buttons } }) => {
-        context.actions = (buttons as { name: string; request: RuntimeAction }[]).map(({ name, request }) => ({
-          name,
-          request,
-        }));
-        return context;
-      })
-    );
-    runtime.registerStep(
-      CardV2TraceComponent(({ context }, { payload: { title, imageUrl, description, buttons } }) => {
-        context.messages.push({
-          type: 'card',
-          title,
-          description: description.text,
-          image: imageUrl,
-          actions: buttons.map(({ name, request }) => ({ name, request })),
-        });
-        return context;
-      })
-    );
-    runtime.registerStep({
-      canHandle: ({ type }) => type === Trace.TraceType.CAROUSEL,
-      handle: ({ context }, { payload: { cards } }: Trace.Carousel) => {
-        context.messages.push({
-          type: MessageType.CAROUSEL,
-          cards: cards.map(({ title, description, imageUrl, buttons }) => ({
-            title,
-            description: description.text,
-            image: imageUrl,
-            actions: buttons.map(({ name, request }) => ({ name, request })),
-          })),
-        });
-        return context;
-      },
-    });
-    runtime.registerStep({
-      canHandle: ({ type }) => type === Trace.TraceType.NO_REPLY,
-      handle: ({ context }, _trace) => {
-        const trace = _trace as BaseTypesTrace.NoReplyTrace;
-
-        setNoReplyTimeout(trace.payload.timeout * 1000);
-        setLastInteractionAt(Date.now());
-
-        return context;
-      },
-    });
-    runtime.registerStep({
-      canHandle: ({ type }) => type === Trace.TraceType.END,
-      handle: ({ context }) => {
-        context.messages.push({ type: MessageType.END });
-        return context;
-      },
-    });
-
-    return runtime;
-  }, [verify]);
+              return context;
+            },
+          },
+        ],
+      }),
+    dependencies
+  );
 
   const setTurns = (action: (turns: TurnProps[]) => TurnProps[]) => {
     setSession((prev) => ({ ...prev, turns: action(prev.turns) }));

--- a/packages/react-chat/src/runtime.ts
+++ b/packages/react-chat/src/runtime.ts
@@ -1,0 +1,71 @@
+import {
+  CardV2TraceComponent,
+  ChoiceTraceComponent,
+  RuntimeAction,
+  TextTraceComponent,
+  Trace,
+  TraceDeclaration,
+  VisualTraceComponent,
+} from '@voiceflow/sdk-runtime';
+
+import type { SystemResponseProps } from './components/SystemResponse';
+import { MessageType } from './components/SystemResponse/constants';
+
+export interface RuntimeContext extends Pick<SystemResponseProps, 'messages' | 'actions'> {}
+
+export const TRACES: TraceDeclaration<RuntimeContext, any>[] = [
+  TextTraceComponent(({ context }, { payload }) => {
+    const { slate, message } = payload;
+
+    context.messages.push({
+      type: MessageType.TEXT,
+      text: slate?.content || message,
+      delay: payload.delay,
+      ...(payload.ai ? { ai: payload.ai } : {}),
+    });
+    return context;
+  }),
+  VisualTraceComponent(({ context }, { payload: { image } }) => {
+    context.messages.push({ type: MessageType.IMAGE, url: image });
+    return context;
+  }),
+  ChoiceTraceComponent(({ context }, { payload: { buttons } }) => {
+    context.actions = (buttons as { name: string; request: RuntimeAction }[]).map(({ name, request }) => ({
+      name,
+      request,
+    }));
+    return context;
+  }),
+  CardV2TraceComponent(({ context }, { payload: { title, imageUrl, description, buttons } }) => {
+    context.messages.push({
+      type: 'card',
+      title,
+      description: description.text,
+      image: imageUrl,
+      actions: buttons.map(({ name, request }) => ({ name, request })),
+    });
+    return context;
+  }),
+  {
+    canHandle: ({ type }) => type === Trace.TraceType.CAROUSEL,
+    handle: ({ context }, { payload: { cards } }: Trace.Carousel) => {
+      context.messages.push({
+        type: MessageType.CAROUSEL,
+        cards: cards.map(({ title, description, imageUrl, buttons }) => ({
+          title,
+          description: description.text,
+          image: imageUrl,
+          actions: buttons.map(({ name, request }) => ({ name, request })),
+        })),
+      });
+      return context;
+    },
+  },
+  {
+    canHandle: ({ type }) => type === Trace.TraceType.END,
+    handle: ({ context }) => {
+      context.messages.push({ type: MessageType.END });
+      return context;
+    },
+  },
+];

--- a/packages/react-chat/src/runtime.ts
+++ b/packages/react-chat/src/runtime.ts
@@ -13,7 +13,7 @@ import { MessageType } from './components/SystemResponse/constants';
 
 export interface RuntimeContext extends Pick<SystemResponseProps, 'messages' | 'actions'> {}
 
-export const TRACES: TraceDeclaration<RuntimeContext, any>[] = [
+export const MESSAGE_TRACES: TraceDeclaration<RuntimeContext, any>[] = [
   TextTraceComponent(({ context }, { payload }) => {
     const { slate, message } = payload;
 

--- a/packages/react-chat/src/views/ChatWindow/index.tsx
+++ b/packages/react-chat/src/views/ChatWindow/index.tsx
@@ -23,7 +23,7 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
   const close = useCallback(() => sendMessage({ type: PostMessage.Type.CLOSE }), []);
   const saveSession = useCallback((session: SessionOptions) => sendMessage({ type: PostMessage.Type.SAVE_SESSION, payload: session }), []);
 
-  const runtime = useRuntime({ versionID, verify, url, user, session, saveSession });
+  const runtime = useRuntime({ versionID, verify, url, user, session, saveSession }, [verify.projectID]);
 
   // listeners
   Listeners.useListenMessage(PostMessage.Type.INTERACT, ({ payload }) => runtime.interact(payload));


### PR DESCRIPTION
### Brief description. What is this change?

- expose `traces` option to configure runtime declaratively
- avoid using `verify` as a dependency for memoization since it may be created during render
- make it easier to reuse `SystemMessage` without the matching logic
  - make `message` prop optional

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test