### PR TITLE
fix: do not set the status if it is already set (DX-610)

### DIFF
--- a/packages/react-chat/src/hooks/useRuntime.ts
+++ b/packages/react-chat/src/hooks/useRuntime.ts
@@ -98,7 +98,7 @@ export const useRuntime = ({ url = RUNTIME_URL, versionID, verify, user, ...conf
     setSession((prev) => ({ ...prev, turns: action(prev.turns) }));
   };
   const setStatus = (status: SessionStatus) => {
-    setSession((prev) => ({ ...prev, status }));
+    setSession((prev) => (prev.status === status ? prev : { ...prev, status }));
   };
   const isStatus = (status: SessionStatus) => {
     return sessionRef.current.status === status;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-610**

### Brief description. What is this change?

Fix an infinite looping issue that occurs when the chat ends
![image](https://cdn.discordapp.com/attachments/1142581318027321354/1143211025441759252/image.png)


### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test