### PR TITLE
fix: remove break br tag insertion (CV3-370)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-conventional": "17.0.3",
     "@voiceflow/commitlint-config": "2.0.0",
-    "@voiceflow/git-branch-check": "1.4.0",
+    "@voiceflow/git-branch-check": "1.4.1",
     "cz-conventional-changelog": "^3.3.0",
     "depcheck": "^1.4.3",
     "fixpack": "^4.0.0",

--- a/packages/react-chat/src/components/Text/Markdown.tsx
+++ b/packages/react-chat/src/components/Text/Markdown.tsx
@@ -16,6 +16,7 @@ const MarkdownText = styled(ReactMarkdown, {
   },
   p: {
     marginTop: 0,
+    whiteSpace: 'pre-wrap',
   },
   'img,video': {
     maxWidth: '100%',

--- a/packages/react-chat/src/components/Text/Markdown.tsx
+++ b/packages/react-chat/src/components/Text/Markdown.tsx
@@ -37,6 +37,11 @@ MarkdownText.defaultProps = {
   rehypePlugins: [rehypeRaw],
   remarkPlugins: [remarkGfm],
   linkTarget: '_blank',
+  remarkRehypeOptions: {
+    handlers: {
+      break: () => [{ type: 'text', value: '\n' }],
+    },
+  },
 };
 
 export default MarkdownText;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,14 +5293,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voiceflow/git-branch-check@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@voiceflow/git-branch-check@npm:1.4.0"
+"@voiceflow/git-branch-check@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@voiceflow/git-branch-check@npm:1.4.1"
   dependencies:
     current-git-branch: ^1.1.0
   bin:
     git-branch-check: index.js
-  checksum: 5996aa674d774823c6a370eabf27ae8f2de2510d6bde462d769fbae3ebb8fb6b4a0459799f01f29152a2535ee0f4371a43f67ddcddedb24930797923e06fe384
+  checksum: 7573d448d4bc3f4b5fb548bab72cae68ae378c67f09ee1a1f555b2e62357ad0854990492b5ac8e3a5d1dbfc50c79cbf5d450f7fddc17f41405392bd1c9de12a8
   languageName: node
   linkType: hard
 
@@ -18991,7 +18991,7 @@ __metadata:
     "@commitlint/cli": 17.0.3
     "@commitlint/config-conventional": 17.0.3
     "@voiceflow/commitlint-config": 2.0.0
-    "@voiceflow/git-branch-check": 1.4.0
+    "@voiceflow/git-branch-check": 1.4.1
     cz-conventional-changelog: ^3.3.0
     depcheck: ^1.4.3
     fixpack: ^4.0.0


### PR DESCRIPTION
I went down a bit of a deep rabbit hole for this one.

So first off, in Markdown, it is standard practice to collapse spaces:
If I wrote "test&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;test"
it would show up as "test     test", the only reason the ^above works is because I injected in `&nbsp;` characters.
For the most part, our text editor works to the same extent as the Github Markdown.

HOWEVER, for regular people who don't use markdown, they expect their spaces to be shown properly. If I type 5 spaces on Microsoft word, I should have 5 spaces. This is why in the styling we have:
https://github.com/voiceflow/react-chat/blob/1e76651fdfa9a015b0a689e4fefd6c4e0a8b5cee/packages/react-chat/src/components/Text/Markdown.tsx#L17-L20
The `prewrap` helps preserve all the whitespace and is essential to displaying the text as it was written.

Now for `react-markdown`. It's actually just a pipeline of a few different things, but from a high level:
`remarkParse` -> `whatever remark plugins` -> `remarkRehype` -> `whatever rehype plugins` -> `rehypeFilter`

If you look at `remarkParse` (v8.03) you will see this code:
https://github.com/remarkjs/remark/blob/daddcb463af2d5b2115496c395d0571c0ff87d15/packages/remark-parse/lib/tokenize/break.js
The `var minBreakLength = 2` is the culprit in the actual bug submitted by our users.
This entire sequence will replace `any whitespace` + `\n` + `any whitespace` with a `'break'` object.

Further downstream with `remarkRehype` (and subsequent libraries), it does this:
https://github.com/syntax-tree/mdast-util-to-hast/blob/a4f9d57e4ef16f32747374db60497fb18a5dbd80/lib/handlers/break.js#L21-L26
note: 
```
export function hardBreak(state, node) {
  /** @type {Element} */
  const result = {type: 'element', tagName: 'br', properties: {}, children: []}
  state.patch(node, result)
  return [state.applyData(node, result), {type: 'text', value: '\n'}]
}
```
This will create a new <br/> tag AND a `\n`

What I've done here is simply make it `\n` and do not inject the `<br/>` - this fixes it for all `pre-warp` cases