### PR TITLE
fix: move api out of react-chat (CT-000)

### DIFF
--- a/packages/react-chat/index.ts
+++ b/packages/react-chat/index.ts
@@ -2,6 +2,7 @@ export * from './src/common';
 export * from './src/components';
 export * from './src/contexts';
 export * from './src/hooks';
+export * from './src/runtime';
 export * from './src/styles';
 export * from './src/types/turn';
 export * from './src/utils/functional';

--- a/packages/react-chat/package.json
+++ b/packages/react-chat/package.json
@@ -12,7 +12,6 @@
     "@voiceflow/sdk-runtime": "1.7.0",
     "@voiceflow/slate-serializer": "1.5.5",
     "@voiceflow/voiceflow-types": "3.26.9",
-    "bowser": "^2.11.0",
     "chroma-js": "2.4.2",
     "clsx": "1.2.1",
     "csstype": "3.1.0",

--- a/packages/react-chat/src/browser/index.tsx
+++ b/packages/react-chat/src/browser/index.tsx
@@ -3,8 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { Listeners, PostMessage } from '@/common';
 import ChatWindow from '@/views/ChatWindow';
 
-import { mergeAssistant } from './utils';
-
 const VOICEFLOW_CHAT_ID = 'vfchat';
 
 const rootEl = document.createElement('div');
@@ -12,16 +10,6 @@ rootEl.id = VOICEFLOW_CHAT_ID;
 document.body.appendChild(rootEl);
 
 const root = createRoot(rootEl);
-
-const fetchAssistant: Listeners.MessageListener<PostMessage.Type.FETCH_ASSISTANT> = {
-  type: PostMessage.Type.FETCH_ASSISTANT,
-  action: async ({ payload }) => {
-    const assistant = await mergeAssistant(payload);
-    ChatWindow.sendMessage({ type: PostMessage.Type.FETCHED_ASSISTANT, payload: assistant });
-  },
-};
-
-Listeners.context.listeners.push(fetchAssistant);
 
 const initialize: Listeners.MessageListener<PostMessage.Type.SESSION> = {
   type: PostMessage.Type.SESSION,

--- a/packages/react-chat/src/common/listeners.ts
+++ b/packages/react-chat/src/common/listeners.ts
@@ -59,3 +59,9 @@ export const useListenMessage = <T extends PostMessage.Type>(type: T, action: (l
     };
   }, []);
 };
+
+export const sendMessage = (message: PostMessage.AnyMessage) => {
+  const encodedMessage = JSON.stringify(message);
+  window.postMessage(encodedMessage);
+  window.parent.postMessage(encodedMessage, '*');
+};

--- a/packages/react-chat/src/common/postMessage.ts
+++ b/packages/react-chat/src/common/postMessage.ts
@@ -1,34 +1,31 @@
 import type { RuntimeAction } from '@voiceflow/sdk-runtime';
 
+import { RuntimeContext } from '@/runtime';
+import { UserTurnProps } from '@/types';
+
 import { Assistant, ChatConfig, SessionOptions } from './types';
 import { isObject } from './utils';
 
 export enum Type {
-  FETCH_ASSISTANT = 'voiceflow:fetch_assistant',
-  FETCHED_ASSISTANT = 'voiceflow:fetched_assistant',
-
   SESSION = 'voiceflow:session',
 
   SAVE_SESSION = 'voiceflow:save_session',
 
+  ACTION_REQUEST = 'voiceflow:action_request',
+  ACTION_RESPONSE = 'voiceflow:action_response',
+
+  SAVE_TRANSCRIPT = 'voiceflow:save_transcript',
+  SAVE_FEEDBACK = 'voiceflow:save_feedback',
+
+  SET_NO_REPLY_TIMEOUT = 'voiceflow:set_no_reply_timeout',
+
   OPEN = 'voiceflow:open',
   CLOSE = 'voiceflow:close',
-  INTERACT = 'voiceflow:interact',
 }
 
 export interface Message {
   type: Type;
   payload?: unknown;
-}
-
-export interface FetchAssistant extends Message {
-  type: Type.FETCH_ASSISTANT;
-  payload: ChatConfig;
-}
-
-export interface FetchedAssistant extends Message {
-  type: Type.FETCHED_ASSISTANT;
-  payload: Assistant;
 }
 
 export interface Session extends Message {
@@ -48,12 +45,35 @@ export interface Close extends Message {
   type: Type.CLOSE;
 }
 
-export interface Interact extends Message {
-  type: Type.INTERACT;
-  payload: RuntimeAction;
+export interface ActionRequest extends Message {
+  type: Type.ACTION_REQUEST;
+  payload: { action: RuntimeAction };
 }
 
-export type AnyMessage = FetchAssistant | FetchedAssistant | Session | SaveSession | Open | Close | Interact;
+export interface ActionResponse extends Message {
+  type: Type.ACTION_RESPONSE;
+  payload: { context: RuntimeContext };
+}
+
+export interface SaveTranscript extends Message {
+  type: Type.SAVE_TRANSCRIPT;
+}
+
+export interface SaveFeedback extends Message {
+  type: Type.SAVE_FEEDBACK;
+  payload: {
+    name: string;
+    text: string[];
+    last_user_input: UserTurnProps | null;
+  };
+}
+
+export interface SetNoReplyTimeout extends Message {
+  type: Type.SET_NO_REPLY_TIMEOUT;
+  payload: { timeout: number };
+}
+
+export type AnyMessage = Session | SaveSession | Open | Close | ActionRequest | ActionResponse | SaveTranscript | SaveFeedback | SetNoReplyTimeout;
 
 export type MessageTypeMap<T extends AnyMessage = AnyMessage> = { [K in T['type']]: T extends { type: K } ? T : never };
 

--- a/packages/react-chat/src/constants.ts
+++ b/packages/react-chat/src/constants.ts
@@ -1,5 +1,3 @@
-export const RUNTIME_URL = 'https://general-runtime.voiceflow.com';
-
 export enum ClassName {
   ASSISTANT_INFO = 'vfrc-assistant-info',
   AVATAR = 'vfrc-avatar',

--- a/packages/react-chat/src/styles/index.ts
+++ b/packages/react-chat/src/styles/index.ts
@@ -1,3 +1,4 @@
 export * from './animation';
+export * from './color';
 export * from './fragments';
 export * from './theme';

--- a/packages/react-chat/src/views/ChatWidget/index.tsx
+++ b/packages/react-chat/src/views/ChatWidget/index.tsx
@@ -43,7 +43,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ children, chatAPI, sendMessage,
       close,
       hide: () => setHidden(true),
       show: () => setHidden(false),
-      interact: (action: RuntimeAction) => sendMessage({ type: PostMessage.Type.INTERACT, payload: action }),
+      interact: (action: RuntimeAction) => sendMessage({ type: PostMessage.Type.ACTION_REQUEST, payload: { action } }),
       proactive: {
         clear: () => setProactiveMessages([]),
         push: (...messages: Trace.AnyTrace[]) => setProactiveMessages((prev) => [...prev, ...messages]),

--- a/packages/react-chat/src/views/ChatWindow/index.tsx
+++ b/packages/react-chat/src/views/ChatWindow/index.tsx
@@ -12,7 +12,6 @@ import { TurnType, UserTurnProps } from '@/types';
 import { useResolveAssistantStyleSheet } from '@/utils/stylesheet';
 
 import { ChatWindowContainer } from './styled';
-import { sendMessage } from './utils';
 
 const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: SessionOptions }> = ({
   assistant,
@@ -23,13 +22,12 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
   session,
 }) => {
   // emitters
-  const close = useCallback(() => sendMessage({ type: PostMessage.Type.CLOSE }), []);
-  const saveSession = useCallback((session: SessionOptions) => sendMessage({ type: PostMessage.Type.SAVE_SESSION, payload: session }), []);
+  const close = useCallback(() => Listeners.sendMessage({ type: PostMessage.Type.CLOSE }), []);
+  const saveSession = useCallback((session: SessionOptions) => Listeners.sendMessage({ type: PostMessage.Type.SAVE_SESSION, payload: session }), []);
 
-  const runtime = useRuntime({ versionID, verify, url, user, session, saveSession }, [verify.projectID]);
+  const runtime = useRuntime({ versionID, verify, url, user, session, saveSession });
 
   // listeners
-  Listeners.useListenMessage(PostMessage.Type.INTERACT, ({ payload }) => runtime.interact(payload));
   Listeners.useListenMessage(PostMessage.Type.OPEN, async (): Promise<void> => {
     if (runtime.isStatus(SessionStatus.IDLE)) {
       await handleStart();
@@ -104,4 +102,4 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
   );
 };
 
-export default Object.assign(ChatWindow, { sendMessage, Container: ChatWindowContainer });
+export default Object.assign(ChatWindow, { Container: ChatWindowContainer });

--- a/packages/react-chat/src/views/ChatWindow/utils.ts
+++ b/packages/react-chat/src/views/ChatWindow/utils.ts
@@ -1,7 +1,0 @@
-import { PostMessage } from '@/common';
-
-export const sendMessage = (message: PostMessage.AnyMessage) => {
-  const encodedMessage = JSON.stringify(message);
-  window.postMessage(encodedMessage);
-  window.parent.postMessage(encodedMessage, '*');
-};

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@voiceflow/react-chat": "workspace:*",
+    "@voiceflow/sdk-runtime": "1.7.0",
+    "bowser": "^2.11.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.0.1",
     "@vitest/coverage-c8": "^0.23.1",
+    "@voiceflow/base-types": "^2.96.3",
     "@voiceflow/eslint-config": "6.1.0",
     "@voiceflow/prettier-config": "1.2.1",
     "@voiceflow/sdk-runtime": "1.7.0",
@@ -33,6 +34,7 @@
     "husky": "^8.0.0",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
+    "type-fest": "^4.6.0",
     "vite": "3.2.2",
     "vite-plugin-html": "3.2.0",
     "vite-tsconfig-paths": "^3.5.0"

--- a/packages/widget/src/api/assistant.ts
+++ b/packages/widget/src/api/assistant.ts
@@ -1,25 +1,9 @@
 /* eslint-disable no-console */
+import { Assistant, ChatConfig, ChatPersistence, ChatPosition, isEnumValue, isObject } from '@voiceflow/react-chat';
 import { VoiceflowRuntime } from '@voiceflow/sdk-runtime';
 import type { PartialDeep } from 'type-fest';
 
-import { Assistant, ChatConfig, ChatPersistence, ChatPosition, isEnumValue, isObject } from '@/common';
-import { RUNTIME_URL } from '@/constants';
-import { PRIMARY } from '@/styles/color';
-
-const DEFAULT_AVATAR = 'https://cdn.voiceflow.com/assets/logo.png';
-
-const DEFAULT_ASSISTANT: Assistant = {
-  title: 'Voiceflow Assistant',
-  image: DEFAULT_AVATAR,
-  avatar: DEFAULT_AVATAR,
-  color: PRIMARY,
-  description: '',
-  position: ChatPosition.RIGHT,
-  watermark: true,
-  feedback: false,
-  persistence: ChatPersistence.LOCAL_STORAGE,
-  spacing: { bottom: 30, side: 30 },
-};
+import { DEFAULT_ASSISTANT, RUNTIME_URL } from './constants';
 
 const sanitizeAssistant = (assistant: unknown): PartialDeep<Assistant> => {
   const ref = isObject(assistant) ? assistant : {};

--- a/packages/widget/src/api/constants.ts
+++ b/packages/widget/src/api/constants.ts
@@ -1,0 +1,18 @@
+import { Assistant, ChatPersistence, ChatPosition, PRIMARY } from '@voiceflow/react-chat';
+
+export const RUNTIME_URL = 'https://general-runtime.voiceflow.com';
+
+export const DEFAULT_AVATAR = 'https://cdn.voiceflow.com/assets/logo.png';
+
+export const DEFAULT_ASSISTANT: Assistant = {
+  title: 'Voiceflow Assistant',
+  image: DEFAULT_AVATAR,
+  avatar: DEFAULT_AVATAR,
+  color: PRIMARY,
+  description: '',
+  position: ChatPosition.RIGHT,
+  watermark: true,
+  feedback: false,
+  persistence: ChatPersistence.LOCAL_STORAGE,
+  spacing: { bottom: 30, side: 30 },
+};

--- a/packages/widget/src/api/listeners.ts
+++ b/packages/widget/src/api/listeners.ts
@@ -1,0 +1,90 @@
+import type { Trace } from '@voiceflow/base-types';
+import { Listeners, MESSAGE_TRACES, PostMessage, RuntimeOptions, SessionOptions } from '@voiceflow/react-chat';
+import { ActionType, VoiceflowRuntime } from '@voiceflow/sdk-runtime';
+import Bowser from 'bowser';
+
+import { RUNTIME_URL } from './constants';
+
+const createContext = () => ({
+  messages: [],
+});
+
+export const initializeAPIListeners = (session: SessionOptions, { user, verify, url = RUNTIME_URL, versionID }: RuntimeOptions) => {
+  const sessionID = session.userID;
+
+  const runtime = new VoiceflowRuntime({
+    verify,
+    url,
+    traces: [
+      ...MESSAGE_TRACES,
+      {
+        canHandle: ({ type }) => type === ActionType.NO_REPLY,
+        handle: ({ context }, _trace) => {
+          const trace = _trace as Trace.NoReplyTrace;
+
+          if (trace.payload.timeout) {
+            Listeners.sendMessage({
+              type: PostMessage.Type.SET_NO_REPLY_TIMEOUT,
+              payload: {
+                timeout: trace.payload.timeout,
+              },
+            });
+          }
+
+          return context;
+        },
+      },
+    ],
+  });
+
+  const ActionRequestListener: Listeners.MessageListener<PostMessage.Type.ACTION_REQUEST> = {
+    type: PostMessage.Type.ACTION_REQUEST,
+    action: async ({ payload: { action } }) => {
+      const context = await runtime.interact(createContext(), { sessionID, action, ...(versionID && { versionID }) });
+
+      Listeners.sendMessage({
+        type: PostMessage.Type.ACTION_RESPONSE,
+        payload: {
+          context,
+        },
+      });
+    },
+  };
+
+  const SaveTranscriptListener: Listeners.MessageListener<PostMessage.Type.SAVE_TRANSCRIPT> = {
+    type: PostMessage.Type.SAVE_TRANSCRIPT,
+    action: async () => {
+      const {
+        browser: { name: browser },
+        os: { name: os },
+        platform: { type: device },
+      } = Bowser.parse(window.navigator.userAgent);
+
+      await runtime.createTranscript(sessionID, {
+        ...(os && { os }),
+        ...(browser && { browser }),
+        ...(device && { device }),
+        ...(user && { user }),
+      });
+    },
+  };
+
+  const SaveFeedbackListener: Listeners.MessageListener<PostMessage.Type.SAVE_FEEDBACK> = {
+    type: PostMessage.Type.SAVE_FEEDBACK,
+    action: async ({ payload: { text, name, last_user_input } }) => {
+      await runtime.feedback({
+        sessionID,
+        text,
+        name,
+        last_user_input,
+        ...(versionID && { versionID }),
+      });
+    },
+  };
+
+  const listeners = [ActionRequestListener, SaveTranscriptListener, SaveFeedbackListener];
+  // ensure unique listeners
+  const listenerTypes = new Set(listeners.map(({ type }) => type));
+  Listeners.context.listeners = Listeners.context.listeners.filter(({ type }) => !listenerTypes.has(type));
+  Listeners.context.listeners.push(...listeners);
+};

--- a/packages/widget/src/index.tsx
+++ b/packages/widget/src/index.tsx
@@ -2,6 +2,8 @@ import { Assistant, ChatWidget, Listeners, PostMessage, RuntimeOptions, useState
 import type { PublicVerify } from '@voiceflow/sdk-runtime';
 import React, { useCallback, useRef } from 'react';
 
+import { mergeAssistant } from './api/assistant';
+import { initializeAPIListeners } from './api/listeners';
 import { useSendMessage } from './hooks';
 import { getSession, saveSession } from './session';
 
@@ -12,25 +14,29 @@ interface WidgetProps extends React.PropsWithChildren, RuntimeOptions<PublicVeri
 
 const Widget: React.FC<WidgetProps> = ({ children, widgetURL, ...config }) => {
   /** initialization */
-  const chatRef = useRef<HTMLIFrameElement>(null);
   const [assistant, setAssistant, assistantRef] = useStateRef<Assistant | undefined>();
 
-  const sendMessage = useSendMessage(chatRef, widgetURL);
-  const onLoad = useCallback(() => sendMessage({ type: PostMessage.Type.FETCH_ASSISTANT, payload: config }), [config]);
+  const chatRef = useRef<HTMLIFrameElement>(null);
 
-  // rely on iframe to fetch assistant configuration
-  Listeners.useListenMessage(PostMessage.Type.FETCHED_ASSISTANT, ({ payload: assistant }) => {
+  const sendMessage = useSendMessage(chatRef, widgetURL);
+
+  const onLoad = useCallback(async () => {
+    const assistant = await mergeAssistant(config);
     setAssistant(assistant);
+
+    const session = getSession(assistant.persistence, config.verify.projectID, config.userID);
 
     sendMessage({
       type: PostMessage.Type.SESSION,
       payload: {
         ...config,
         assistant,
-        session: getSession(assistant.persistence, config.verify.projectID, config.userID),
+        session,
       },
     });
-  });
+
+    initializeAPIListeners(session, config);
+  }, [config]);
 
   Listeners.useListenMessage(PostMessage.Type.SAVE_SESSION, ({ payload }) => {
     const persistence = assistantRef.current?.persistence;

--- a/packages/widget/src/index.tsx
+++ b/packages/widget/src/index.tsx
@@ -35,7 +35,7 @@ const Widget: React.FC<WidgetProps> = ({ children, widgetURL, ...config }) => {
       },
     });
 
-    initializeAPIListeners(session, config);
+    initializeAPIListeners(sendMessage, session, config);
   }, [config]);
 
   Listeners.useListenMessage(PostMessage.Type.SAVE_SESSION, ({ payload }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5228,6 +5228,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@voiceflow/base-types@npm:^2.96.3":
+  version: 2.96.3
+  resolution: "@voiceflow/base-types@npm:2.96.3"
+  dependencies:
+    "@voiceflow/common": ^8.2.2
+    slate: 0.94.1
+  checksum: 3607ff5899408244d3106b45098d07ef9dfdbf945a96bfe639b887fa2be1a573921ae74108587d4a6fa1cb024e3bd5d2fec960cc70f1d9219e53befc9598edce
+  languageName: node
+  linkType: hard
+
 "@voiceflow/chat-types@npm:^2.13.72":
   version: 2.13.72
   resolution: "@voiceflow/chat-types@npm:2.13.72"
@@ -5284,6 +5294,25 @@ __metadata:
     shallowequal: ^1.1.0
     typescript-fsa: 3.0.0
   checksum: fffc2ccbd9cc475daa95c9c06a6b4a6dc82775d8fa8352c49776afad04a79ed58ecb2e416e3fed42506708faa1cf5453e0482ecf7867f89f2d9e96bfdb142bef
+  languageName: node
+  linkType: hard
+
+"@voiceflow/common@npm:^8.2.2":
+  version: 8.2.2
+  resolution: "@voiceflow/common@npm:8.2.2"
+  dependencies:
+    "@types/crypto-js": ^4.0.2
+    "@types/shallowequal": ^1.1.1
+    bson-objectid: ^2.0.1
+    crypto-js: ^4.1.1
+    cuid: ^2.1.8
+    dayjs: 1.10.7
+    lodash: ^4.17.21
+    murmurhash-wasm: ^1.3.0
+    number-to-words: ^1.2.4
+    shallowequal: ^1.1.0
+    typescript-fsa: 3.0.0
+  checksum: b6889b58e3f77108d6198e02e09bd4bd9d81f5aeece93d7ebb1213a37de2e5677cb224e9cc7c1476a1a05b0ed4df49f73bea8ef6c45d0ce3f800c3013e8a66f1
   languageName: node
   linkType: hard
 
@@ -5476,6 +5505,7 @@ __metadata:
     "@types/react-dom": ^18.0.6
     "@vitejs/plugin-react": ^2.0.1
     "@vitest/coverage-c8": ^0.23.1
+    "@voiceflow/base-types": ^2.96.3
     "@voiceflow/eslint-config": 6.1.0
     "@voiceflow/prettier-config": 1.2.1
     "@voiceflow/react-chat": "workspace:*"
@@ -5493,6 +5523,7 @@ __metadata:
     prettier: 2.7.1
     react: 18.2.0
     react-dom: 18.2.0
+    type-fest: ^4.6.0
     vite: 3.2.2
     vite-plugin-html: 3.2.0
     vite-tsconfig-paths: ^3.5.0
@@ -21089,6 +21120,13 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "type-fest@npm:4.6.0"
+  checksum: e38f2b4b35e912bf60dbe7d4350653fb76b241a456e849fab85002ba08e938a26a7c44a330dd5620dd48ce57566be7c97e997064dc0d5066d5b6949b8c444430
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5371,7 +5371,6 @@ __metadata:
     "@voiceflow/slate-serializer": 1.5.5
     "@voiceflow/tsconfig": 1.4.8
     "@voiceflow/voiceflow-types": 3.26.9
-    bowser: ^2.11.0
     chroma-js: 2.4.2
     clsx: 1.2.1
     csstype: 3.1.0
@@ -5483,6 +5482,7 @@ __metadata:
     "@voiceflow/sdk-runtime": 1.7.0
     "@voiceflow/tsconfig": 1.4.8
     babel-loader: ^8.2.5
+    bowser: ^2.11.0
     depcheck: 1.4.3
     eslint: 7.32.0
     eslint-output: ^3.0.1


### PR DESCRIPTION
This is not at all the prettiest code, but the goal here was to move ALL `general-runtime` api calls outside of the iframe itself and into the bundle.mjs that the script injects. I can clean things up more later.
This allows the browser to say the "origin" of the call is from the embedded website.

<img width="999" alt="Screenshot 2023-11-03 at 1 26 55 AM" src="https://github.com/voiceflow/react-chat/assets/5643574/973dc268-3b3c-4c39-9557-ff8d0e0846a8">

I'm heavily relying on our "listener" system to send messages where there used to be an API call.


I've tested that transcripts continue to work
react-chat still works

I'm not sure how to test the feedback system.