### PR TITLE
fix: launch options (CT-000)

### DIFF
--- a/packages/react-chat/src/common/types.ts
+++ b/packages/react-chat/src/common/types.ts
@@ -1,3 +1,4 @@
+import { BaseRequest } from '@voiceflow/base-types';
 import type { AuthVerify, PublicVerify, RuntimeAction, RuntimeOptions as SDKRuntimeOptions } from '@voiceflow/sdk-runtime';
 import { ChatPersistence, ChatPosition, ChatPublishing } from '@voiceflow/voiceflow-types/build/cjs/version/chat';
 
@@ -7,6 +8,10 @@ export { ChatPersistence, ChatPosition };
 export type { RuntimeAction };
 
 export type SendMessage = (message: string, action: RuntimeAction) => Promise<void>;
+
+export interface LaunchOptions {
+  event?: BaseRequest.BaseRequest;
+}
 
 export interface RuntimeOptions<Verify extends AuthVerify | PublicVerify = AuthVerify | PublicVerify> extends Omit<SDKRuntimeOptions<Verify>, 'url'> {
   url?: string | undefined;
@@ -18,6 +23,7 @@ export interface RuntimeOptions<Verify extends AuthVerify | PublicVerify = AuthV
     | undefined;
   userID?: string;
   versionID?: string | undefined;
+  launch?: LaunchOptions;
 }
 
 export enum SessionStatus {

--- a/packages/react-chat/src/hooks/useRuntime.ts
+++ b/packages/react-chat/src/hooks/useRuntime.ts
@@ -3,7 +3,7 @@ import { serializeToText } from '@voiceflow/slate-serializer/text';
 import cuid from 'cuid';
 import { useEffect, useState } from 'react';
 
-import { Listeners, PostMessage, RuntimeOptions, SendMessage, SessionOptions, SessionStatus } from '@/common';
+import { LaunchOptions, Listeners, PostMessage, RuntimeOptions, SendMessage, SessionOptions, SessionStatus } from '@/common';
 import type { MessageProps } from '@/components/SystemResponse';
 import { MessageType } from '@/components/SystemResponse/constants';
 import { TurnProps, TurnType, UserTurnProps } from '@/types';
@@ -131,11 +131,11 @@ export const useRuntime = ({ versionID, verify, user, ...config }: UseRuntimePro
 
   const reset = () => setTurns(() => []);
 
-  const launch = async (): Promise<void> => {
+  const launch = async ({ event }: LaunchOptions = {}): Promise<void> => {
     if (sessionRef.current.turns.length) reset();
 
     setStatus(SessionStatus.ACTIVE);
-    await interact({ type: BaseRequest.RequestType.LAUNCH, payload: null });
+    await interact(event ?? { type: BaseRequest.RequestType.LAUNCH, payload: null });
   };
 
   const reply = async (message: string): Promise<void> => send(message, { type: BaseRequest.RequestType.TEXT, payload: message });

--- a/packages/react-chat/src/views/ChatWindow/index.tsx
+++ b/packages/react-chat/src/views/ChatWindow/index.tsx
@@ -20,6 +20,7 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
   user,
   url,
   session,
+  launch,
 }) => {
   // emitters
   const close = useCallback(() => Listeners.sendMessage({ type: PostMessage.Type.CLOSE }), []);
@@ -35,7 +36,7 @@ const ChatWindow: React.FC<ChatConfig & { assistant: Assistant; session: Session
   });
 
   const handleStart = async (): Promise<void> => {
-    await runtime.launch();
+    await runtime.launch(launch);
   };
 
   const closeAndEnd = useCallback((): void => {


### PR DESCRIPTION
users can now add something like:
```
launch: {
  event: { type: 'launch', payload: { internalUserID: 1345, email: "test@voiceflow.com" } }
}
```

to pass additional context when the chat starts. They can also start it with a particular event or from a particular intent. This provides more optionality of starting from different diagrams.