### PR TITLE
fix: no reply timeout (ACT-014)

### DIFF
--- a/packages/react-chat/src/components/SystemResponse/constants.ts
+++ b/packages/react-chat/src/components/SystemResponse/constants.ts
@@ -5,3 +5,5 @@ export enum MessageType {
   CAROUSEL = 'carousel',
   END = 'END',
 }
+
+export const DEFAULT_MESSAGE_DELAY = 1000;

--- a/packages/react-chat/src/components/SystemResponse/hooks.ts
+++ b/packages/react-chat/src/components/SystemResponse/hooks.ts
@@ -3,6 +3,7 @@ import { match } from 'ts-pattern';
 
 import { useDidUpdateEffect } from '@/hooks';
 
+import { DEFAULT_MESSAGE_DELAY } from './constants';
 import { MessageProps } from './types';
 
 export * from './types';
@@ -16,8 +17,6 @@ type Animation<T extends AnimationType = AnimationType> = {
   [AnimationType.MESSAGE]: { type: AnimationType.MESSAGE; message: MessageProps };
   [AnimationType.INDICATOR]: { type: AnimationType.INDICATOR; messageDelay: number };
 }[T];
-
-const DEFAULT_MESSAGE_DELAY = 1000;
 
 const createAnimateIndicator = (messageDelay: number = DEFAULT_MESSAGE_DELAY): Animation<AnimationType.INDICATOR> => ({
   type: AnimationType.INDICATOR,

--- a/packages/react-chat/src/contexts/RuntimeContext/index.tsx
+++ b/packages/react-chat/src/contexts/RuntimeContext/index.tsx
@@ -1,10 +1,10 @@
 import React, { createContext, useMemo } from 'react';
 
-import { Settings, useRuntimeState } from './useRuntimeState';
+import { RuntimeState, Settings, useRuntimeState } from './useRuntimeState';
 
 // split up API and state to prevent unnecessary re-renders
-export const RuntimeStateAPIContext = createContext<ReturnType<typeof useRuntimeState>['api']>({} as any);
-export const RuntimeStateContext = createContext<ReturnType<typeof useRuntimeState>['state']>({} as any);
+export const RuntimeStateAPIContext = createContext<RuntimeState['api']>({} as any);
+export const RuntimeStateContext = createContext<RuntimeState['state']>({} as any);
 
 interface RuntimeProviderProps extends React.PropsWithChildren, Settings {}
 

--- a/packages/react-chat/src/contexts/RuntimeContext/useNoReply.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/useNoReply.ts
@@ -1,0 +1,29 @@
+import { BaseRequest } from '@voiceflow/base-types';
+import { useCallback, useRef } from 'react';
+
+import { SessionStatus } from '@/common';
+
+import type { RuntimeState } from './useRuntimeState';
+
+export const useNoReply = (api: () => Pick<RuntimeState['api'], 'interact' | 'isStatus'>) => {
+  const noReplyTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const clearNoReplyTimeout = useCallback(() => {
+    if (!noReplyTimeout.current) return;
+
+    clearTimeout(noReplyTimeout.current);
+    noReplyTimeout.current = null;
+  }, []);
+
+  const setNoReplyTimeout = useCallback((timeout: number) => {
+    clearNoReplyTimeout();
+    noReplyTimeout.current = setTimeout(() => {
+      // Trigger no reply action
+      if (!api().isStatus(SessionStatus.ACTIVE)) return;
+
+      api().interact({ type: BaseRequest.RequestType.NO_REPLY, payload: null });
+    }, timeout);
+  }, []);
+
+  return { setNoReplyTimeout, clearNoReplyTimeout };
+};


### PR DESCRIPTION
The old `useEffect(, [noReplyTimeout, lastInteractionAt])` system was totally broken, and also very hard to follow and read. Fraught with side effects.
I have no idea why they had to be calculated independently.

there was no way to reset `noReplyTimeout` so it was ALWAYS on. `lastInteractionAt` would always change so it would always reset the `noReplyTimeout`.

This would mean the moment you set a NoReply, for the rest of the conversation NoReply would apply.

I've abstracted it into a new explicit API: `clearNoReplyTimeout` and `setNoReplyTimeout`

I've also adjusted how we were calculating the timeout.