### PR TITLE
feat: fix card image height (BUG-637)

### DIFF
--- a/packages/react-chat/src/components/Card/index.tsx
+++ b/packages/react-chat/src/components/Card/index.tsx
@@ -16,7 +16,7 @@ const Card: React.FC<CardProps> = ({ title, description, image, actions = [] }) 
 
   return (
     <Container>
-      {!!image && <Image.Background image={image} />}
+      {!!image && <Image.Default image={image} />}
       <Content>
         {!!title && <Header>{title}</Header>}
         {!!description &&


### PR DESCRIPTION
Using a Default image instead of background seems to solve the issue for both Card and Carousel:

![Screenshot 2023-11-27 at 12 26 06](https://github.com/voiceflow/react-chat/assets/9748039/3737cfa6-ed98-44db-a9dd-da7354af8020)
