### PR TITLE
fix: stop event propagation from chat input (ACT-000)

### DIFF
--- a/packages/react-chat/src/components/ChatInput/index.tsx
+++ b/packages/react-chat/src/components/ChatInput/index.tsx
@@ -18,6 +18,8 @@ const ChatInput: React.FC<ChatInputProps> = ({ id, onSend, ...props }) => {
   const internalID = useMemo(() => `vf-chat-input--${cuid()}`, []) ?? id;
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    event.stopPropagation();
+
     if (event.key !== 'Enter') return;
 
     event.preventDefault();
@@ -26,7 +28,7 @@ const ChatInput: React.FC<ChatInputProps> = ({ id, onSend, ...props }) => {
 
   return (
     <Container>
-      <Input id={internalID} onKeyPress={handleKeyPress} {...props} />
+      <Input id={internalID} onKeyDown={handleKeyPress} {...props} />
       <ButtonContainer htmlFor={internalID} withContent={!!props.value}>
         <Bubble size="small" svg="smallArrowUp" onClick={onSend} />
       </ButtonContainer>


### PR DESCRIPTION
Before we had an iframe and all events would've been separated.

I've tested with the reported customer's website using the `/alpha/` bundle and this fixes their issue. As long as there are no other serious side effects, this is fine.