### PR TITLE
feat: prevent user message while indicator is on (BUG-739)

### DIFF
--- a/packages/react-chat/src/components/Chat/index.tsx
+++ b/packages/react-chat/src/components/Chat/index.tsx
@@ -24,6 +24,11 @@ export interface ChatProps extends HeaderProps, AssistantInfoProps, FooterProps,
   isLoading: boolean;
 
   /**
+   * If true, it is expecting a message from the server.
+   */
+  hasIndicator: boolean;
+
+  /**
    * A unix timestamp indicating the start of the conversation.
    */
   startTime?: Nullish<number>;
@@ -52,6 +57,7 @@ const Chat: React.FC<ChatProps> = ({
   description,
   startTime,
   isLoading,
+  hasIndicator,
   withWatermark,
   onMinimize,
   onEnd,
@@ -99,7 +105,7 @@ const Chat: React.FC<ChatProps> = ({
           {hasEnded && <Status>You have ended the chat</Status>}
         </AutoScrollProvider>
       </Dialog>
-      <Footer withWatermark={withWatermark} hasEnded={hasEnded} onStart={onStart} onSend={onSend} />
+      <Footer isDisabled={hasIndicator} withWatermark={withWatermark} hasEnded={hasEnded} onStart={onStart} onSend={onSend} />
       <Overlay />
       <Prompt accept={{ label: 'End Chat', type: 'warn', onClick: chain(onEnd, handleResume) }} cancel={{ label: 'Cancel', onClick: handleResume }} />
     </Container>

--- a/packages/react-chat/src/components/Footer/index.tsx
+++ b/packages/react-chat/src/components/Footer/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-autofocus */
+
 import { useState } from 'react';
 
 import Button from '@/components/Button';
@@ -18,6 +20,11 @@ export interface FooterProps {
   hasEnded?: boolean | undefined;
 
   /**
+   * If true, the user is prevented from typing and sending messages
+   */
+  isDisabled?: boolean | undefined;
+
+  /**
    * A callback to start a new conversation.
    */
   onStart?: (() => Promise<void>) | undefined;
@@ -28,14 +35,12 @@ export interface FooterProps {
   onSend?: ((message: string) => Promise<void>) | undefined;
 }
 
-const Footer: React.FC<FooterProps> = ({ withWatermark, hasEnded, onStart, onSend }) => {
+const Footer: React.FC<FooterProps> = ({ withWatermark, hasEnded, isDisabled, onStart, onSend }) => {
   const [message, setMessage] = useState('');
   const [buffering, setBuffering] = useState(false);
 
   const handleSend = async (): Promise<void> => {
-    if (!message || buffering) return;
-
-    setBuffering(true);
+    if (!message || isDisabled || buffering) return;
 
     setMessage('');
     await onSend?.(message);
@@ -48,8 +53,15 @@ const Footer: React.FC<FooterProps> = ({ withWatermark, hasEnded, onStart, onSen
       {hasEnded ? (
         <Button onClick={onStart}>Start New Chat</Button>
       ) : (
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        <ChatInput value={message} placeholder="Message…" autoFocus onValueChange={setMessage} onSend={handleSend} buffering={buffering} />
+        <ChatInput
+          autoFocus
+          value={message}
+          placeholder="Message…"
+          onValueChange={setMessage}
+          onSend={handleSend}
+          buffering={buffering}
+          disabled={isDisabled}
+        />
       )}
       {withWatermark && (
         <Watermark>

--- a/packages/react-chat/src/views/ChatWindow/index.tsx
+++ b/packages/react-chat/src/views/ChatWindow/index.tsx
@@ -46,6 +46,7 @@ const ChatWindow: React.FC = () => {
         onEnd={closeAndEnd}
         onSend={runtime.reply}
         onMinimize={runtime.close}
+        hasIndicator={state.indicator}
       >
         {state.session.turns.map((turn, turnIndex) =>
           match(turn)
@@ -57,10 +58,10 @@ const ChatWindow: React.FC = () => {
                 feedback={
                   assistant.feedback
                     ? {
-                        onClick: (feedback: FeedbackName) => {
-                          runtime.feedback(feedback, props.messages, getPreviousUserTurn(turnIndex));
-                        },
-                      }
+                      onClick: (feedback: FeedbackName) => {
+                        runtime.feedback(feedback, props.messages, getPreviousUserTurn(turnIndex));
+                      },
+                    }
                     : undefined
                 }
                 avatar={assistant.avatar}


### PR DESCRIPTION
[Apparently](https://voiceflow.atlassian.net/jira/software/c/projects/CV3/boards/39?assignee=621458878e1bf000692ff209&selectedIssue=BUG-739) allowing the user to send messages while we're waiting for the server to respond can cause some unintended behaviors.

This PR is a proposal to prevent this.