### PR TITLE
feat: add voiceflow:interact event to differentiate from voiceflow:save_session (DX-1078)

### DIFF
--- a/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
@@ -108,6 +108,7 @@ export const useRuntimeState = ({ assistant, config }: Settings) => {
       ...context,
     });
 
+    broadcast({ type: BroadcastType.INTERACT, payload: { session: sessionRef.current, action } });
     saveSession(assistant.persistence, config.verify.projectID, sessionRef.current);
   };
 

--- a/packages/react-chat/src/utils/broadcast.ts
+++ b/packages/react-chat/src/utils/broadcast.ts
@@ -1,7 +1,11 @@
+import { BaseRequest } from '@voiceflow/base-types';
+
 import { SessionOptions } from '@/common';
 
 export enum BroadcastType {
   SAVE_SESSION = 'voiceflow:save_session',
+
+  INTERACT = 'voiceflow:interact',
 
   OPEN = 'voiceflow:open',
   CLOSE = 'voiceflow:close',
@@ -17,6 +21,14 @@ export interface SaveSession extends BroadcastMessage {
   payload: SessionOptions;
 }
 
+export interface Interact extends BroadcastMessage {
+  type: BroadcastType.INTERACT;
+  payload: {
+    session: SessionOptions;
+    action: BaseRequest.BaseRequest;
+  };
+}
+
 export interface Open extends BroadcastMessage {
   type: BroadcastType.OPEN;
 }
@@ -24,7 +36,7 @@ export interface Close extends BroadcastMessage {
   type: BroadcastType.CLOSE;
 }
 
-export type AnyMessage = SaveSession | Open | Close;
+export type AnyMessage = SaveSession | Interact | Open | Close;
 
 // send messages so that other scripts can listen to them
 // https://developer.voiceflow.com/docs/chat-widget#events


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-1078**

### Brief description. What is this change?

Add a unique event `voiceflow:interact` that can be used to capture all user interactions (and allows us to evolve `voiceflow:save_session` safely)

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test