### PR TITLE
feat: effect and response extension support (DX-1100)

### DIFF
--- a/packages/react-chat/e2e/extensions.html
+++ b/packages/react-chat/e2e/extensions.html
@@ -42,11 +42,17 @@
     <form>
       <input name="name" placeholder="What is your name?" />
       <fieldset>
-        <legend>What is your role?</legend>
-        <input type="radio" name="role" id="developer" value="developer" checked /><label
-          for="developer">Developer</label>
-        <input type="radio" name="role" id="designer" value="designer" /><label for="designer">Designer</label>
-        <input type="radio" name="role" id="manager" value="manager" /><label for="manager">Manager</label>
+        <legend>What kind of hair do you have?</legend>
+        <div>
+          <input type="radio" name="hair" id="straight" value="straight" checked /><label
+            for="straight">Straight</label>
+        </div>
+        <div>
+          <input type="radio" name="hair" id="curly" value="curly" /><label for="curly">Curly</label>
+        </div>
+        <div>
+          <input type="radio" name="hair" id="wavy" value="wavy" /><label for="wavy">Wavy</label>
+        </div>
       </fieldset>
       <button>submit</button>
     </form>
@@ -88,7 +94,14 @@
                   const form = element.querySelector(`#${id}`);
                   form.addEventListener('submit', async (event) => {
                     event.preventDefault();
-                    await window.voiceflow.chat.interact({ type: 'submit', payload: { role: 'my role' } });
+
+                    await window.voiceflow.chat.interact({
+                      type: 'submit',
+                      payload: {
+                        name: form.elements.name.value,
+                        hair: form.elements.hair.value
+                      }
+                    });
                     while (form.firstChild) {
                       form.removeChild(form.firstChild);
                     }

--- a/packages/react-chat/e2e/extensions.html
+++ b/packages/react-chat/e2e/extensions.html
@@ -18,6 +18,7 @@
 
     #order-status {
       position: absolute;
+      visibility: hidden;
       left: 50%;
       top: 8px;
       transform: translateX(-50%);
@@ -37,11 +38,24 @@
   <span id="order-status" data-testid="status"></span>
   <div id="voiceflow-chat-frame">
   </div>
+  <template id="complex-form">
+    <form>
+      <input name="name" placeholder="What is your name?" />
+      <fieldset>
+        <legend>What is your role?</legend>
+        <input type="radio" name="role" id="developer" value="developer" checked /><label
+          for="developer">Developer</label>
+        <input type="radio" name="role" id="designer" value="designer" /><label for="designer">Designer</label>
+        <input type="radio" name="role" id="manager" value="manager" /><label for="manager">Manager</label>
+      </fieldset>
+      <button>submit</button>
+    </form>
+  </template>
 
   <script type="text/javascript">
     (function (d, t) {
       var v = d.createElement(t), s = d.getElementsByTagName(t)[0];
-      v.onload = function () {
+      v.onload = () => {
         window.voiceflow.chat.load({
           verify: { projectID: 'projectID' },
           render: { mode: 'embedded' },
@@ -51,12 +65,39 @@
               {
                 name: 'order_tracker',
                 type: 'effect',
-                match: function ({ trace }) { return trace.type === 'update_order_status'; },
-                effect: function ({ trace }) {
-                  var el = document.getElementById('order-status');
-                  var status = trace.payload
+                match: ({ trace }) => trace.type === 'update_order_status',
+                effect({ trace }) {
+                  const element = document.getElementById('order-status');
+                  const status = trace.payload;
 
-                  el.innerText = status;
+                  element.style.visibility = 'visible';
+                  element.innerText = status;
+                }
+              },
+              {
+                name: 'onboarding_form',
+                type: 'response',
+                match: ({ trace }) => trace.type === 'onboarding',
+                render({ trace, element }) {
+                  const template = document.getElementById('complex-form').content.cloneNode(true);
+                  const id = 'onboarding-form-' + Date.now();
+                  template.firstElementChild.id = id;
+
+                  element.appendChild(template);
+
+                  const form = element.querySelector(`#${id}`);
+                  form.addEventListener('submit', async (event) => {
+                    event.preventDefault();
+                    await window.voiceflow.chat.interact({ type: 'submit', payload: { role: 'my role' } });
+                    while (form.firstChild) {
+                      form.removeChild(form.firstChild);
+                    }
+
+                    const confirmation = document.createElement('em');
+                    confirmation.innerText = `submitted ✅`;
+
+                    form.appendChild(confirmation);
+                  });
                 }
               }
             ]

--- a/packages/react-chat/e2e/extensions.html
+++ b/packages/react-chat/e2e/extensions.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Embedded Mode</title>
+  <style>
+    body {
+      background-color: #f9f9f9;
+    }
+
+    #voiceflow-chat-frame {
+      width: 100vw;
+      height: 100vh;
+      position: fixed;
+      top: 0;
+      left: 0;
+    }
+
+    #order-status {
+      position: absolute;
+      left: 50%;
+      top: 8px;
+      transform: translateX(-50%);
+      padding: 8px;
+      border-radius: 10px;
+      background-color: orangered;
+      z-index: 10;
+
+      font-family: 'Open Sans', sans-serif;
+      font-size: 20px;
+      font-weight: 400;
+    }
+  </style>
+</head>
+
+<body>
+  <span id="order-status" data-testid="status"></span>
+  <div id="voiceflow-chat-frame">
+  </div>
+
+  <script type="text/javascript">
+    (function (d, t) {
+      var v = d.createElement(t), s = d.getElementsByTagName(t)[0];
+      v.onload = function () {
+        window.voiceflow.chat.load({
+          verify: { projectID: 'projectID' },
+          render: { mode: 'embedded' },
+          autostart: true,
+          assistant: {
+            extensions: [
+              {
+                name: 'order_tracker',
+                type: 'effect',
+                match: function ({ trace }) { return trace.type === 'update_order_status'; },
+                effect: function ({ trace }) {
+                  var el = document.getElementById('order-status');
+                  var status = trace.payload
+
+                  el.innerText = status;
+                }
+              }
+            ]
+          }
+        });
+      }
+      v.src = "../dist/bundle.mjs"; v.type = "text/javascript"; s.parentNode.insertBefore(v, s);
+    })(document, 'script');
+  </script>
+</body>
+
+</html>

--- a/packages/react-chat/e2e/extensions.spec.ts
+++ b/packages/react-chat/e2e/extensions.spec.ts
@@ -109,6 +109,5 @@ test('render response extension from incoming trace', async ({ page }) => {
   await extensionMessage.locator('[name="name"]').fill('Alex');
   await extensionMessage.locator('[name="hair"][id="curly"]').click();
   await extensionMessage.getByRole('button').click();
-
-  expect(extensionMessage).toHaveText(`submitted ✅`);
+  await page.locator('.vfrc-message--extension-onboarding_form', { hasText: `submitted ✅` }).waitFor({ state: 'visible' });
 });

--- a/packages/react-chat/e2e/extensions.spec.ts
+++ b/packages/react-chat/e2e/extensions.spec.ts
@@ -47,10 +47,7 @@ test('trigger effect extension on incoming trace', async ({ page }) => {
   await chat.waitFor({ state: 'visible' });
   expect(chat).toBeInViewport();
 
-  const status = page.getByTestId('status');
-  await status.waitFor({ state: 'visible' });
-  expect(status).toHaveText('idle');
-
+  await page.locator('[data-testid="status"]', { hasText: 'idle' }).waitFor({ state: 'visible' });
   await page.locator('.vfrc-message', { hasText: systemMessages[0] }).waitFor({ state: 'visible' });
 
   const input = page.locator('.vfrc-chat-input textarea');
@@ -62,15 +59,14 @@ test('trigger effect extension on incoming trace', async ({ page }) => {
 
   await page.locator('.vfrc-message', { hasText: userMessages[0] }).waitFor({ state: 'visible' });
   await page.locator('.vfrc-message', { hasText: systemMessages[1] }).waitFor({ state: 'visible' });
-  await page.getByTestId('status').waitFor({ state: 'visible' });
-  expect(status).toHaveText('in progress');
+  await page.locator('[data-testid="status"]', { hasText: 'in progress' }).waitFor({ state: 'visible' });
 
   await input.fill(userMessages[1]);
   await submit.click();
 
   await page.locator('.vfrc-message', { hasText: userMessages[1] }).waitFor({ state: 'visible' });
   await page.locator('.vfrc-message', { hasText: systemMessages[2] }).waitFor({ state: 'visible' });
-  expect(status).toHaveText('ordered');
+  await page.locator('[data-testid="status"]', { hasText: 'ordered' }).waitFor({ state: 'visible' });
 });
 
 test('render response extension from incoming trace', async ({ page }) => {

--- a/packages/react-chat/e2e/extensions.spec.ts
+++ b/packages/react-chat/e2e/extensions.spec.ts
@@ -77,14 +77,7 @@ test('render response extension from incoming trace', async ({ page }) => {
   await page.route(RUNTIME_URL, (route) =>
     route.fulfill({
       json: {
-        trace: [
-          slateMessage("Welcome to Sal's Salon! Tell me about yourself."),
-          {
-            type: 'onboarding',
-            defaultPath: 0,
-            paths: [{ event: { type: 'submit' } }],
-          },
-        ],
+        trace: [slateMessage("Welcome to Sal's Salon! Tell me about yourself."), { type: 'onboarding' }],
       },
     })
   );

--- a/packages/react-chat/e2e/extensions.spec.ts
+++ b/packages/react-chat/e2e/extensions.spec.ts
@@ -1,0 +1,86 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { expect, test } from '@playwright/test';
+
+const FIRST_MESSAGE = 'Welcome to the pizza palace!';
+const FIRST_RESPONSE = 'I want to order a pizza';
+const SECOND_MESSAGE = 'What kind of pizza do you want?';
+const SECOND_RESPONSE = 'Cheese please';
+const THIRD_MESSAGE = 'Your pizza is on the way!';
+
+const slateMessage = (text: string) => ({
+  type: 'text',
+  payload: {
+    slate: {
+      id: text,
+      content: [{ children: [{ text }] }],
+      messageDelayMilliseconds: 100,
+    },
+    message: text,
+    delay: 100,
+  },
+});
+
+test('trigger effect extension on incoming trace', async ({ page }) => {
+  let count = 0;
+
+  // eslint-disable-next-line consistent-return
+  await page.route('https://general-runtime.voiceflow.com/public/projectID/state/user/*/interact', async (route) => {
+    count++;
+
+    switch (count) {
+      case 1:
+        return route.fulfill({
+          json: {
+            trace: [{ type: 'update_order_status', payload: 'idle' }, slateMessage(FIRST_MESSAGE)],
+          },
+        });
+
+      case 2:
+        return route.fulfill({
+          json: {
+            trace: [{ type: 'update_order_status', payload: 'in progress' }, slateMessage(SECOND_MESSAGE)],
+          },
+        });
+
+      case 3:
+        return route.fulfill({
+          json: {
+            trace: [{ type: 'update_order_status', payload: 'ordered' }, slateMessage(THIRD_MESSAGE)],
+          },
+        });
+
+      default:
+    }
+  });
+
+  await page.goto('extensions');
+
+  const chat = page.locator('.vfrc-chat');
+  await chat.waitFor({ state: 'visible' });
+  expect(chat).toBeInViewport();
+
+  const status = page.getByTestId('status');
+  await status.waitFor({ state: 'visible' });
+  expect(status).toHaveText('idle');
+
+  await page.locator('.vfrc-message', { hasText: FIRST_MESSAGE }).waitFor({ state: 'visible' });
+
+  const input = page.locator('.vfrc-chat-input textarea');
+  await input.waitFor({ state: 'visible' });
+  await input.fill(FIRST_RESPONSE);
+
+  const submit = page.locator('.vfrc-chat-input .vfrc-bubble');
+  await submit.click();
+
+  await page.locator('.vfrc-message', { hasText: FIRST_RESPONSE }).waitFor({ state: 'visible' });
+  await page.locator('.vfrc-message', { hasText: SECOND_MESSAGE }).waitFor({ state: 'visible' });
+  await page.getByTestId('status').waitFor({ state: 'visible' });
+  expect(status).toHaveText('in progress');
+
+  await input.fill(SECOND_RESPONSE);
+  await submit.click();
+
+  await page.locator('.vfrc-message', { hasText: SECOND_RESPONSE }).waitFor({ state: 'visible' });
+  await page.locator('.vfrc-message', { hasText: THIRD_MESSAGE }).waitFor({ state: 'visible' });
+  expect(status).toHaveText('ordered');
+});

--- a/packages/react-chat/e2e/utils.ts
+++ b/packages/react-chat/e2e/utils.ts
@@ -1,0 +1,12 @@
+export const slateMessage = (text: string) => ({
+  type: 'text',
+  payload: {
+    slate: {
+      id: text,
+      content: [{ children: [{ text }] }],
+      messageDelayMilliseconds: 100,
+    },
+    message: text,
+    delay: 100,
+  },
+});

--- a/packages/react-chat/src/components/SystemResponse/ExtensionMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/ExtensionMessage.tsx
@@ -1,0 +1,26 @@
+import { Trace } from '@voiceflow/base-types';
+import { useEffect, useRef } from 'react';
+
+import { ResponseExtension } from '@/dtos/Extension.dto';
+
+import Message from '../Message';
+
+export interface ExtensionMessageProps {
+  extensions: ResponseExtension[];
+  trace: Trace.AnyTrace;
+}
+
+export const ExtensionMessage: React.FC<ExtensionMessageProps> = ({ extensions, trace }) => {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line xss/no-mixed-html
+    extensions.forEach((extension) => extension.render?.({ trace, element: ref.current as HTMLElement }));
+  }, []);
+
+  return (
+    <Message from="system">
+      <span ref={ref} />
+    </Message>
+  );
+};

--- a/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
@@ -12,6 +12,7 @@ import { RuntimeStateAPIContext } from '@/contexts';
 
 import Feedback, { FeedbackProps } from '../Feedback';
 import { MessageType } from './constants';
+import { ExtensionMessage } from './ExtensionMessage';
 import EndState from './state/end';
 import { Controls, List, MessageContainer } from './styled';
 import { MessageProps } from './types';
@@ -68,6 +69,7 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timesta
               .with({ type: MessageType.CAROUSEL }, (props) => (
                 <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
               ))
+              .with({ type: MessageType.EXTENSION }, ({ payload }) => <ExtensionMessage extensions={payload.extensions} trace={payload.trace} />)
               .otherwise(() => null)}
           {feedback && <Feedback {...feedback} />}
         </List>

--- a/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/react-chat/src/components/SystemResponse/SystemMessage.tsx
@@ -69,7 +69,7 @@ const SystemMessage: React.FC<SystemMessageProps> = ({ avatar, feedback, timesta
               .with({ type: MessageType.CAROUSEL }, (props) => (
                 <Carousel {...R.omit(props, ['type'])} containerRef={containerRef} controlsRef={controlsRef} />
               ))
-              .with({ type: MessageType.EXTENSION }, ({ payload }) => <ExtensionMessage extensions={payload.extensions} trace={payload.trace} />)
+              .with({ type: MessageType.EXTENSION }, ({ payload }) => <ExtensionMessage extension={payload.extension} trace={payload.trace} />)
               .otherwise(() => null)}
           {feedback && <Feedback {...feedback} />}
         </List>

--- a/packages/react-chat/src/components/SystemResponse/constants.ts
+++ b/packages/react-chat/src/components/SystemResponse/constants.ts
@@ -4,6 +4,7 @@ export enum MessageType {
   CARD = 'card',
   CAROUSEL = 'carousel',
   END = 'END',
+  EXTENSION = 'EXTENSION',
 }
 
 export const DEFAULT_MESSAGE_DELAY = 1000;

--- a/packages/react-chat/src/components/SystemResponse/types.ts
+++ b/packages/react-chat/src/components/SystemResponse/types.ts
@@ -38,7 +38,7 @@ export interface ExtensionMessage extends BaseMessageProps {
   type: StringifiedEnum<MessageType.EXTENSION>;
   payload: {
     trace: Trace.AnyTrace;
-    extensions: ResponseExtension[];
+    extension: ResponseExtension;
   };
 }
 

--- a/packages/react-chat/src/components/SystemResponse/types.ts
+++ b/packages/react-chat/src/components/SystemResponse/types.ts
@@ -1,6 +1,7 @@
-import { Text } from '@voiceflow/base-types';
+import { Text, Trace } from '@voiceflow/base-types';
 
 import { CardProps } from '@/components/Card/types';
+import { ResponseExtension } from '@/dtos/Extension.dto';
 import { StringifiedEnum } from '@/types/util';
 
 import { MessageType } from './constants';
@@ -33,9 +34,24 @@ export interface EndMessage extends BaseMessageProps {
   type: StringifiedEnum<MessageType.END>;
 }
 
+export interface ExtensionMessage extends BaseMessageProps {
+  type: StringifiedEnum<MessageType.EXTENSION>;
+  payload: {
+    trace: Trace.AnyTrace;
+    extensions: ResponseExtension[];
+  };
+}
+
 export interface CustomMessage extends BaseMessageProps {
   type: `custom_${string}`;
   payload: any;
 }
 
-export type MessageProps = TextMessageProps | ImageMessageProps | CardMessageProps | CarouselMessageProps | EndMessage | CustomMessage;
+export type MessageProps =
+  | TextMessageProps
+  | ImageMessageProps
+  | CardMessageProps
+  | CarouselMessageProps
+  | EndMessage
+  | ExtensionMessage
+  | CustomMessage;

--- a/packages/react-chat/src/contexts/RuntimeContext/traces/EffectExtensions.trace.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/traces/EffectExtensions.trace.ts
@@ -1,0 +1,31 @@
+import { Trace } from '@voiceflow/base-types';
+import { TraceDeclaration } from '@voiceflow/sdk-runtime';
+
+import { AnyExtension, EffectExtension, ExtensionType } from '@/dtos/Extension.dto';
+
+import { RuntimeMessage } from '../messages';
+
+export const EffectExtensions = (extensions: AnyExtension[]): TraceDeclaration<RuntimeMessage, Trace.AnyTrace> => {
+  const effectExtensions = extensions.filter((extension): extension is EffectExtension => extension.type === ExtensionType.EFFECT);
+
+  return {
+    // accept all traces to pass them on to extensions
+    canHandle: () => true,
+
+    handle: ({ context }, trace) => {
+      // NOTE: these promises are intentionally left unhandled
+      // we just want to capture and raise any errors thrown
+      effectExtensions.forEach(async (extension) => {
+        if (!extension.match({ trace })) return;
+
+        try {
+          await extension.effect?.({ trace });
+        } catch (e) {
+          console.error(`Extension '${extension.name}' threw an error: ${e}`);
+        }
+      });
+
+      return context;
+    },
+  };
+};

--- a/packages/react-chat/src/contexts/RuntimeContext/traces/NoReply.trace.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/traces/NoReply.trace.ts
@@ -1,0 +1,21 @@
+import { Trace } from '@voiceflow/base-types';
+import { ActionType, TraceDeclaration } from '@voiceflow/sdk-runtime';
+
+import { DEFAULT_MESSAGE_DELAY } from '@/components/SystemResponse/constants';
+
+import { RuntimeMessage } from '../messages';
+
+export const NoReply = (callback: (timeout: number) => void): TraceDeclaration<RuntimeMessage, any> => ({
+  canHandle: ({ type }) => type === ActionType.NO_REPLY,
+  handle: ({ context }, trace: Trace.NoReplyTrace) => {
+    if (trace.payload?.timeout) {
+      // messages take 1 second to animate in, on top of the delay
+      const messageDelays = context.messages.reduce((acc, message) => acc + (message.delay ?? 1000) + DEFAULT_MESSAGE_DELAY, 0);
+      const timeout = trace.payload.timeout * 1000 + messageDelays;
+
+      // eslint-disable-next-line callback-return
+      callback(timeout);
+    }
+    return context;
+  },
+});

--- a/packages/react-chat/src/contexts/RuntimeContext/traces/ResponseExtensions.trace.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/traces/ResponseExtensions.trace.ts
@@ -1,0 +1,27 @@
+import { Trace } from '@voiceflow/base-types';
+import { TraceDeclaration } from '@voiceflow/sdk-runtime';
+
+import { MessageType } from '@/components/SystemResponse/constants';
+import { AnyExtension, ExtensionType, ResponseExtension } from '@/dtos/Extension.dto';
+
+import { RuntimeMessage } from '../messages';
+
+export const ResponseExtensions = (extensions: AnyExtension[]): TraceDeclaration<RuntimeMessage, Trace.AnyTrace> => {
+  const responseExtensions = extensions.filter((extension): extension is ResponseExtension => extension.type === ExtensionType.RESPONSE);
+
+  return {
+    // accept all traces to pass them on to extensions for matching
+    canHandle: () => true,
+
+    handle: ({ context }, trace) => {
+      const matching = responseExtensions.filter((extension) => extension.match({ trace }));
+
+      // only add a message node if there's going to be an extension rendering in it
+      if (matching.length) {
+        context.messages.push({ type: MessageType.EXTENSION, payload: { trace, extensions: matching } });
+      }
+
+      return context;
+    },
+  };
+};

--- a/packages/react-chat/src/contexts/RuntimeContext/traces/ResponseExtensions.trace.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/traces/ResponseExtensions.trace.ts
@@ -6,22 +6,16 @@ import { AnyExtension, ExtensionType, ResponseExtension } from '@/dtos/Extension
 
 import { RuntimeMessage } from '../messages';
 
-export const ResponseExtensions = (extensions: AnyExtension[]): TraceDeclaration<RuntimeMessage, Trace.AnyTrace> => {
-  const responseExtensions = extensions.filter((extension): extension is ResponseExtension => extension.type === ExtensionType.RESPONSE);
+export const ResponseExtensions = (extensions: AnyExtension[]): TraceDeclaration<RuntimeMessage, Trace.AnyTrace>[] => {
+  return extensions
+    .filter((extension): extension is ResponseExtension => extension.type === ExtensionType.RESPONSE)
+    .map((extension) => ({
+      canHandle: (trace) => extension.match({ trace }),
 
-  return {
-    // accept all traces to pass them on to extensions for matching
-    canHandle: () => true,
+      handle: ({ context }, trace) => {
+        context.messages.push({ type: MessageType.EXTENSION, payload: { trace, extension } });
 
-    handle: ({ context }, trace) => {
-      const matching = responseExtensions.filter((extension) => extension.match({ trace }));
-
-      // only add a message node if there's going to be an extension rendering in it
-      if (matching.length) {
-        context.messages.push({ type: MessageType.EXTENSION, payload: { trace, extensions: matching } });
-      }
-
-      return context;
-    },
-  };
+        return context;
+      },
+    }));
 };

--- a/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
@@ -14,6 +14,7 @@ import { getSession, saveSession } from '@/utils/session';
 
 import { EffectExtensions } from './traces/EffectExtensions.trace';
 import { NoReply } from './traces/NoReply.trace';
+import { ResponseExtensions } from './traces/ResponseExtensions.trace';
 import { useNoReply } from './useNoReply';
 import { createContext, useRuntimeAPI } from './useRuntimeAPI';
 
@@ -43,7 +44,7 @@ export const useRuntimeState = ({ assistant, config }: Settings) => {
   const runtime = useRuntimeAPI({
     ...config,
     ...session,
-    traceHandlers: [NoReply(setNoReplyTimeout), EffectExtensions(assistant.extensions)],
+    traceHandlers: [NoReply(setNoReplyTimeout), ...EffectExtensions(assistant.extensions), ...ResponseExtensions(assistant.extensions)],
   });
 
   // status management

--- a/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
+++ b/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts
@@ -1,12 +1,9 @@
 import { BaseRequest } from '@voiceflow/base-types';
 import { isTextRequest } from '@voiceflow/base-types/build/cjs/request';
-import { ActionType, Trace, TraceDeclaration } from '@voiceflow/sdk-runtime';
 import cuid from 'cuid';
 import { useState } from 'react';
 
 import { SendMessage, SessionOptions, SessionStatus } from '@/common';
-import { DEFAULT_MESSAGE_DELAY } from '@/components/SystemResponse/constants';
-import type { RuntimeMessage } from '@/contexts/RuntimeContext/messages';
 import { AssistantOptions } from '@/dtos/AssistantOptions.dto';
 import { ChatConfig } from '@/dtos/ChatConfig.dto';
 import { useStateRef } from '@/hooks/useStateRef';
@@ -15,6 +12,8 @@ import { handleActions } from '@/utils/actions';
 import { broadcast, BroadcastType } from '@/utils/broadcast';
 import { getSession, saveSession } from '@/utils/session';
 
+import { EffectExtensions } from './traces/EffectExtensions.trace';
+import { NoReply } from './traces/NoReply.trace';
 import { useNoReply } from './useNoReply';
 import { createContext, useRuntimeAPI } from './useRuntimeAPI';
 
@@ -41,21 +40,11 @@ export const useRuntimeState = ({ assistant, config }: Settings) => {
   const [indicator, setIndicator] = useState(false);
   const { clearNoReplyTimeout, setNoReplyTimeout } = useNoReply(() => ({ interact, isStatus }));
 
-  const noReplyHandler: TraceDeclaration<RuntimeMessage, any> = {
-    canHandle: ({ type }) => type === ActionType.NO_REPLY,
-    handle: ({ context }, trace: Trace.NoReplyTrace) => {
-      if (trace.payload?.timeout) {
-        // messages take 1 second to animate in, on top of the delay
-        const messageDelays = context.messages.reduce((acc, message) => acc + (message.delay ?? 1000) + DEFAULT_MESSAGE_DELAY, 0);
-        const timeout = trace.payload.timeout * 1000 + messageDelays;
-
-        setNoReplyTimeout(timeout);
-      }
-      return context;
-    },
-  };
-
-  const runtime = useRuntimeAPI({ ...config, ...session, traceHandlers: [noReplyHandler] });
+  const runtime = useRuntimeAPI({
+    ...config,
+    ...session,
+    traceHandlers: [NoReply(setNoReplyTimeout), EffectExtensions(assistant.extensions)],
+  });
 
   // status management
   const setStatus = (status: SessionStatus) => {

--- a/packages/react-chat/src/dtos/AssistantOptions.dto.ts
+++ b/packages/react-chat/src/dtos/AssistantOptions.dto.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { ChatPersistence, ChatPosition } from '@/common';
 import { PRIMARY } from '@/styles/color';
 
+import { AnyExtension } from './Extension.dto';
+
 export const DEFAULT_AVATAR = 'https://cdn.voiceflow.com/assets/logo.png';
 
 export type AssistantOptions = z.infer<typeof AssistantOptions>;
@@ -28,5 +30,7 @@ export const AssistantOptions = z
         bottom: z.number().default(30),
       })
       .default({}),
+
+    extensions: AnyExtension.array().default([]),
   })
   .default({});

--- a/packages/react-chat/src/dtos/Extension.dto.ts
+++ b/packages/react-chat/src/dtos/Extension.dto.ts
@@ -27,7 +27,7 @@ export const EffectExtension = Extension(ExtensionType.EFFECT).extend({
 export const ResponseExtension = Extension(ExtensionType.RESPONSE).extend({
   render: z
     .function()
-    .transform((f) => f as (context: { trace: Trace.AnyTrace; element: HTMLElement }) => void)
+    .transform((f) => f as (context: { trace: Trace.AnyTrace; element: HTMLElement }) => (() => void) | void)
     .optional(),
 });
 

--- a/packages/react-chat/src/dtos/Extension.dto.ts
+++ b/packages/react-chat/src/dtos/Extension.dto.ts
@@ -1,0 +1,34 @@
+import { Trace } from '@voiceflow/base-types';
+import { z } from 'zod';
+
+export enum ExtensionType {
+  EFFECT = 'effect',
+  RESPONSE = 'response',
+}
+
+export type EffectExtension = z.infer<typeof EffectExtension>;
+export type ResponseExtension = z.infer<typeof ResponseExtension>;
+export type AnyExtension = z.infer<typeof AnyExtension>;
+
+const Extension = <Type extends ExtensionType>(type: Type) =>
+  z.object({
+    name: z.string(),
+    type: z.literal(type),
+    match: z.function().transform((f) => f as (context: { trace: Trace.AnyTrace }) => boolean),
+  });
+
+export const EffectExtension = Extension(ExtensionType.EFFECT).extend({
+  effect: z
+    .function()
+    .transform((f) => f as (context: { trace: Trace.AnyTrace }) => Promise<void> | void)
+    .optional(),
+});
+
+export const ResponseExtension = Extension(ExtensionType.RESPONSE).extend({
+  render: z
+    .function()
+    .transform((f) => f as (context: { trace: Trace.AnyTrace; element: HTMLElement }) => void)
+    .optional(),
+});
+
+export const AnyExtension = z.discriminatedUnion('type', [EffectExtension, ResponseExtension]);

--- a/packages/react-chat/src/dtos/Extension.dto.ts
+++ b/packages/react-chat/src/dtos/Extension.dto.ts
@@ -17,26 +17,17 @@ const Extension = <Type extends ExtensionType>(type: Type) =>
     match: z.function().transform((f) => f as (context: { trace: Trace.AnyTrace }) => boolean),
   });
 
-export interface EffectExtensionContext {
-  trace: Trace.AnyTrace;
-}
-
 export const EffectExtension = Extension(ExtensionType.EFFECT).extend({
   effect: z
     .function()
-    .transform((f) => f as (context: EffectExtensionContext) => Promise<void> | void)
+    .transform((f) => f as (context: { trace: Trace.AnyTrace }) => Promise<void> | void)
     .optional(),
 });
-
-export interface ResponseExtensionContext {
-  trace: Trace.AnyTrace;
-  element: HTMLElement;
-}
 
 export const ResponseExtension = Extension(ExtensionType.RESPONSE).extend({
   render: z
     .function()
-    .transform((f) => f as (context: ResponseExtensionContext) => void)
+    .transform((f) => f as (context: { trace: Trace.AnyTrace; element: HTMLElement }) => void)
     .optional(),
 });
 

--- a/packages/react-chat/src/dtos/Extension.dto.ts
+++ b/packages/react-chat/src/dtos/Extension.dto.ts
@@ -17,17 +17,26 @@ const Extension = <Type extends ExtensionType>(type: Type) =>
     match: z.function().transform((f) => f as (context: { trace: Trace.AnyTrace }) => boolean),
   });
 
+export interface EffectExtensionContext {
+  trace: Trace.AnyTrace;
+}
+
 export const EffectExtension = Extension(ExtensionType.EFFECT).extend({
   effect: z
     .function()
-    .transform((f) => f as (context: { trace: Trace.AnyTrace }) => Promise<void> | void)
+    .transform((f) => f as (context: EffectExtensionContext) => Promise<void> | void)
     .optional(),
 });
+
+export interface ResponseExtensionContext {
+  trace: Trace.AnyTrace;
+  element: HTMLElement;
+}
 
 export const ResponseExtension = Extension(ExtensionType.RESPONSE).extend({
   render: z
     .function()
-    .transform((f) => f as (context: { trace: Trace.AnyTrace; element: HTMLElement }) => void)
+    .transform((f) => f as (context: ResponseExtensionContext) => void)
     .optional(),
 });
 

--- a/packages/react-chat/src/utils/assistant.test.ts
+++ b/packages/react-chat/src/utils/assistant.test.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 import { ChatPersistence, ChatPosition } from '@/common';
 import { DEFAULT_AVATAR, RawAssistantOptions } from '@/dtos/AssistantOptions.dto';
 import { ChatConfig } from '@/dtos/ChatConfig.dto';
+import { ExtensionType } from '@/dtos/Extension.dto';
 import { PRIMARY } from '@/styles';
 
 import { mergeAssistantOptions } from './assistant';
@@ -36,6 +37,7 @@ describe('assistant utils', () => {
         side: 100,
         bottom: 100,
       },
+      extensions: [{ name: 'remote_extension', type: ExtensionType.EFFECT, match: () => false }],
     };
 
     it('should fallback to default options when not configured', async () => {
@@ -55,6 +57,7 @@ describe('assistant utils', () => {
           side: 30,
           bottom: 30,
         },
+        extensions: [],
       });
     });
 
@@ -64,7 +67,10 @@ describe('assistant utils', () => {
 
       const merged = await mergeAssistantOptions(config, undefined);
 
-      expect(merged).toEqual(remoteOptions);
+      expect(merged).toEqual({
+        ...remoteOptions,
+        extensions: [expect.objectContaining({ name: 'remote_extension', type: ExtensionType.EFFECT })],
+      });
     });
 
     it('should prioritize local options over remote options (with some exceptions)', async () => {
@@ -82,6 +88,7 @@ describe('assistant utils', () => {
           side: 150,
           bottom: 150,
         },
+        extensions: [{ name: 'local_extension', type: ExtensionType.EFFECT, match: () => false }],
 
         // setting these locally should have no effect
         watermark: !remoteOptions.watermark,
@@ -94,6 +101,10 @@ describe('assistant utils', () => {
 
       expect(merged).toEqual({
         ...localOptions,
+        extensions: [
+          expect.objectContaining({ name: 'remote_extension', type: ExtensionType.EFFECT }),
+          expect.objectContaining({ name: 'local_extension', type: ExtensionType.EFFECT }),
+        ],
 
         // verify these setting have not changed from what is remote
         watermark: remoteOptions.watermark,
@@ -126,6 +137,7 @@ describe('assistant utils', () => {
           side: 100,
           bottom: 100,
         },
+        extensions: [],
       });
     });
   });

--- a/packages/react-chat/src/utils/assistant.ts
+++ b/packages/react-chat/src/utils/assistant.ts
@@ -28,7 +28,6 @@ export const mergeAssistantOptions = async (config: ChatConfig, overrides: RawAs
       ...publishing?.spacing,
       ...overrides?.spacing,
     },
-    // TODO: confirm whether this is the desired behaviour
     extensions: [...(publishing?.extensions ?? []), ...(overrides?.extensions ?? [])],
   });
 };

--- a/packages/react-chat/src/utils/assistant.ts
+++ b/packages/react-chat/src/utils/assistant.ts
@@ -28,5 +28,7 @@ export const mergeAssistantOptions = async (config: ChatConfig, overrides: RawAs
       ...publishing?.spacing,
       ...overrides?.spacing,
     },
+    // TODO: confirm whether this is the desired behaviour
+    extensions: [...(publishing?.extensions ?? []), ...(overrides?.extensions ?? [])],
   });
 };

--- a/packages/react-chat/src/utils/chat.ts
+++ b/packages/react-chat/src/utils/chat.ts
@@ -1,5 +1,5 @@
 export const createPlaceholderMethods = (createMessage: (method: string) => string): Omit<VoiceflowChat, 'load' | 'destroy'> => {
-  const noopWarn = (method: string) => () => console.warn(createMessage(method));
+  const noopWarn = (method: string) => (): any => console.warn(createMessage(method));
 
   return {
     open: noopWarn('open'),

--- a/packages/react-chat/typings/global.d.ts
+++ b/packages/react-chat/typings/global.d.ts
@@ -10,7 +10,7 @@ declare global {
     load: (config: LoadConfig) => Promise<void>;
     destroy: () => void;
 
-    interact: (action: RuntimeAction) => void;
+    interact: (action: RuntimeAction) => Promise<void>;
 
     /* overlay mode controls */
     open: VoidFunction;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-1100**

### Brief description. What is this change?

Add extensions (`effect` and `response`) support to the WebChat

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test