### PR TITLE
fix: prevent sending message while waiting (BUG-739)

### DIFF
--- a/packages/react-chat/src/components/Footer/index.tsx
+++ b/packages/react-chat/src/components/Footer/index.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 
 import Button from '@/components/Button';
 import ChatInput from '@/components/ChatInput';
+import { RuntimeStateContext } from '@/contexts/RuntimeContext';
 
 import { Container, Watermark } from './styled';
 
@@ -29,6 +30,7 @@ export interface FooterProps {
 }
 
 const Footer: React.FC<FooterProps> = ({ withWatermark, hasEnded, onStart, onSend }) => {
+  const state = useContext(RuntimeStateContext);
   const [message, setMessage] = useState('');
   const [buffering, setBuffering] = useState(false);
 
@@ -48,8 +50,15 @@ const Footer: React.FC<FooterProps> = ({ withWatermark, hasEnded, onStart, onSen
       {hasEnded ? (
         <Button onClick={onStart}>Start New Chat</Button>
       ) : (
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        <ChatInput value={message} placeholder="Message…" autoFocus onValueChange={setMessage} onSend={handleSend} buffering={buffering} />
+        <ChatInput
+          value={message}
+          placeholder="Message…"
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          onValueChange={setMessage}
+          onSend={handleSend}
+          buffering={state.indicator || buffering}
+        />
       )}
       {withWatermark && (
         <Watermark>


### PR DESCRIPTION
While we are waiting for an interaction:
https://github.com/voiceflow/react-chat/blob/3640462ea35b2258f8ae1fb340ba5736f5ec4512/packages/react-chat/src/contexts/RuntimeContext/useRuntimeState.ts#L87-L93

We will prevent the user from sending a new message. The "send" icon will not be shown and "enter" will not work.
<img width="430" alt="Screenshot 2024-03-19 at 10 38 07 AM" src="https://github.com/voiceflow/react-chat/assets/5643574/df2bb1c4-bf76-4c4e-8296-bc22de3642c9">
