### PR TITLE
fix: add local development workflow (ENG-158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ yarn install
 yarn build
 
 # run dev server
-yarn dev
+yarn local
 ```
 
 Once the server is running it should automatically open your browser with the chat widget.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "turbo run clean && rimraf node_modules",
     "dev": "turbo run dev --no-cache --parallel --continue",
     "lint": "run-p -c lint:eslint lint:prettier",
+    "local": "cd packages/react-chat; yarn local",
     "lint:eslint": "yarn g:eslint",
     "lint:fix": "run-p -c \"g:eslint --fix\" \"g:prettier --write\"",
     "lint:prettier": "yarn g:prettier --check",

--- a/packages/react-chat/package.json
+++ b/packages/react-chat/package.json
@@ -31,6 +31,7 @@
     "lint:eslint": "yarn g:eslint",
     "lint:fix": "yarn g:run-p -c \"lint:eslint --fix\" \"lint:prettier --write\"",
     "lint:prettier": "yarn g:prettier --check",
+    "local": "NODE_ENV=development vite",
     "start:e2e": "http-server -o e2e",
     "tdd": "yarn g:vitest",
     "test": "yarn g:run-p -c test:dependencies test:types test:unit",


### PR DESCRIPTION
I think as part of @effervescentia the local workflow get replaced by storybook.

I've personally found it very helpful because vite allows for HMR while doing dev work. Also the READMEs were out of date.
https://github.com/voiceflow/react-chat/pull/139

<img width="1725" alt="Screenshot 2024-06-21 at 2 55 19 PM" src="https://github.com/voiceflow/react-chat/assets/5643574/8d0d4956-e0c0-473d-a084-0c71157d54e8">
