### PR TITLE
feat: aligning theme colors across components (COR-0000)

### DIFF
--- a/apps/documentation/src/components/StoryEmbed.tsx
+++ b/apps/documentation/src/components/StoryEmbed.tsx
@@ -1,5 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 import type { DecoratorFunction } from '@storybook/types';
+import { PALETTE } from '@voiceflow/chat';
 import { useEffect, useMemo, useState } from 'react';
 
 const Stories = typeof window !== 'undefined' ? require('@voiceflow/chat/stories') : {};

--- a/apps/documentation/src/components/StoryEmbed.tsx
+++ b/apps/documentation/src/components/StoryEmbed.tsx
@@ -1,6 +1,5 @@
 import type { StoryObj } from '@storybook/react';
 import type { DecoratorFunction } from '@storybook/types';
-import { PALETTE } from '@voiceflow/chat';
 import { useEffect, useMemo, useState } from 'react';
 
 const Stories = typeof window !== 'undefined' ? require('@voiceflow/chat/stories') : {};

--- a/packages/chat/src/components/Button/Button.story.tsx
+++ b/packages/chat/src/components/Button/Button.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { WithPalette } from '@/storybook/decorators';
+
 import Button from '.';
 import { ButtonVariant } from './constants';
 
@@ -18,6 +20,7 @@ const meta: Meta<typeof Button> = {
     children: 'Button label',
     round: false,
   },
+  decorators: [WithPalette],
 };
 
 export default meta;

--- a/packages/chat/src/components/Button/index.tsx
+++ b/packages/chat/src/components/Button/index.tsx
@@ -1,16 +1,12 @@
-import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 import { type ComponentPropsWithRef, forwardRef, type PropsWithChildren } from 'react';
 
 import { ClassName } from '@/constants';
-import { createPalette } from '@/styles/colors';
-import { PALETTE } from '@/styles/colors.css';
-import type { IThemedComponent } from '@/types';
 
 import { ButtonVariant } from './constants';
 import { buttonStyles } from './styles.css';
 
-interface ButtonProps extends IThemedComponent, ComponentPropsWithRef<'button'> {
+interface ButtonProps extends ComponentPropsWithRef<'button'> {
   variant?: ButtonVariant;
   round?: boolean;
 }
@@ -21,7 +17,6 @@ const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(({ 
   return (
     <button
       ref={ref}
-      style={assignInlineVars(PALETTE, { colors: createPalette(props.primaryColor) })}
       className={clsx(ClassName.BUTTON, buttonStyles({ type: type ?? ButtonVariant.PRIMARY, round }))}
       {...props}
     >

--- a/packages/chat/src/components/FeedbackButton/FeedbackButton.interface.ts
+++ b/packages/chat/src/components/FeedbackButton/FeedbackButton.interface.ts
@@ -1,6 +1,4 @@
-import type { IThemedComponent } from '@/types/IThemedComponent';
-
-export interface IFeedbackButton extends IThemedComponent {
+export interface IFeedbackButton {
   onClick: () => void;
   variant?: 'up' | 'down';
   active?: boolean;

--- a/packages/chat/src/components/FeedbackButton/FeedbackButton.story.tsx
+++ b/packages/chat/src/components/FeedbackButton/FeedbackButton.story.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 import { COLOR_FIXTURE } from '@/__fixtures__/colors';
+import { createPalette } from '@/styles/colors';
+import { PALETTE } from '@/styles/colors.css';
 
 import { FeedbackButton } from '.';
 
@@ -18,14 +21,15 @@ const VariantRenderer = ({ active }: { active?: boolean }) => {
     <>
       <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
         {COLOR_FIXTURE.map((color, index) => (
-          <FeedbackButton
-            primaryColor={color}
-            variant={index % 2 === 0 ? 'up' : 'down'}
-            active={active}
-            key={index}
-            onClick={() => null}
-            testID={`feedback-button--${index}`}
-          />
+          <div style={assignInlineVars(PALETTE, { colors: createPalette(color) })}>
+            <FeedbackButton
+              variant={index % 2 === 0 ? 'up' : 'down'}
+              active={active}
+              key={index}
+              onClick={() => null}
+              testID={`feedback-button--${index}`}
+            />
+          </div>
         ))}
       </div>
     </>

--- a/packages/chat/src/components/FeedbackButton/FeedbackButton.test.tsx
+++ b/packages/chat/src/components/FeedbackButton/FeedbackButton.test.tsx
@@ -7,7 +7,7 @@ describe('Button', () => {
   it('onClick callback fires properly', async () => {
     const onClick = vi.fn();
 
-    render(<FeedbackButton primaryColor="green" onClick={onClick} />);
+    render(<FeedbackButton onClick={onClick} />);
     screen.getByRole('button').click();
 
     expect(onClick).toHaveBeenCalledTimes(1);

--- a/packages/chat/src/components/FeedbackButton/index.tsx
+++ b/packages/chat/src/components/FeedbackButton/index.tsx
@@ -1,23 +1,15 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-import { createPalette } from '@/styles/colors';
+import { PALETTE } from '@/styles/colors.css';
 
 import { activeBackground, activeIconColor, feedbackButtonStyles, iconStyle } from './FeedbackButton.css';
 import type { IFeedbackButton } from './FeedbackButton.interface';
 import { ThumbsDownIcon } from './ThumbsDownIcon.component';
 import { ThumbsUpIcon } from './ThumbsUpIcon.component';
 
-export const FeedbackButton: React.FC<IFeedbackButton> = ({
-  primaryColor,
-  variant = 'up',
-  active,
-  onClick,
-  testID,
-}) => {
-  const palette = createPalette(primaryColor);
-
-  const buttonActiveColor = palette[500];
-  const iconActiveColor = palette[50];
+export const FeedbackButton: React.FC<IFeedbackButton> = ({ variant = 'up', active, onClick, testID }) => {
+  const buttonActiveColor = PALETTE.colors[500];
+  const iconActiveColor = PALETTE.colors[50];
   const Icon = variant === 'up' ? ThumbsUpIcon : ThumbsDownIcon;
 
   return (

--- a/packages/chat/src/components/Header/Header.story.tsx
+++ b/packages/chat/src/components/Header/Header.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { VF_ICON } from '@/fixtures';
+import { WithPalette } from '@/storybook/decorators';
 
 import Header from '.';
 
@@ -13,6 +14,7 @@ const meta: Meta<typeof Header> = {
     actions: [],
   },
   render: (args) => <Header {...args} />,
+  decorators: [WithPalette],
 };
 
 export default meta;

--- a/packages/chat/src/components/Header/index.tsx
+++ b/packages/chat/src/components/Header/index.tsx
@@ -1,11 +1,7 @@
-import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 
 import Avatar from '@/components/Avatar';
 import { ClassName } from '@/constants';
-import { createPalette } from '@/styles/colors';
-import { PALETTE } from '@/styles/colors.css';
-import type { IThemedComponent } from '@/types';
 
 import Button from '../Button';
 import Icon, { type IconProps } from '../Icon';
@@ -25,7 +21,7 @@ export interface HeaderActionProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 }
 
-export interface HeaderProps extends IThemedComponent {
+export interface HeaderProps {
   /**
    * The name of your assistant or title of the conversation.
    */
@@ -42,11 +38,8 @@ export interface HeaderProps extends IThemedComponent {
   actions?: HeaderActionProps[];
 }
 
-const Header: React.FC<HeaderProps> = ({ primaryColor, title, image, actions = [] }) => (
-  <div
-    style={assignInlineVars(PALETTE, { colors: createPalette(primaryColor) })}
-    className={clsx(ClassName.ICON, headerContainer)}
-  >
+const Header: React.FC<HeaderProps> = ({ title, image, actions = [] }) => (
+  <div className={clsx(ClassName.ICON, headerContainer)}>
     {!!image?.length && <Avatar size="small" avatar={image} />}
     <div className={headerInnerContainer}>
       <div className={headerTitle}>{title}</div>

--- a/packages/chat/src/dtos/Palette.dto.ts
+++ b/packages/chat/src/dtos/Palette.dto.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+import { createPalette } from '@/styles/colors';
+
+export const Palette = z
+  .object({
+    50: z.string(),
+    100: z.string(),
+    200: z.string(),
+    300: z.string(),
+    400: z.string(),
+    500: z.string(),
+    600: z.string(),
+    700: z.string(),
+    800: z.string(),
+    900: z.string(),
+  })
+  .default(createPalette());
+
+export type Palette = z.infer<typeof Palette>;

--- a/packages/chat/src/hooks/usePalette.ts
+++ b/packages/chat/src/hooks/usePalette.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+import type { AssistantOptions } from '@/dtos/AssistantOptions.dto';
+import type { Palette } from '@/dtos/Palette.dto';
+import { createPalette } from '@/styles/colors';
+
+export const usePalette = (assistant?: AssistantOptions) => {
+  const [palette, setPalette] = useState<Palette>();
+  useEffect(() => {
+    if (assistant?.color) {
+      setPalette(createPalette(assistant.color));
+    }
+  }, [assistant?.color]);
+
+  return palette;
+};

--- a/packages/chat/src/storybook/decorators.tsx
+++ b/packages/chat/src/storybook/decorators.tsx
@@ -1,0 +1,12 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import { createPalette } from '@/styles/colors';
+import { PALETTE } from '@/styles/colors.css';
+
+export const WithPalette = (Story: any, { args }: { args: any }) => {
+  return (
+    <div style={assignInlineVars(PALETTE, { colors: createPalette() })}>
+      <Story args={{ ...args }} />
+    </div>
+  );
+};

--- a/packages/chat/src/types/IThemedComponent.ts
+++ b/packages/chat/src/types/IThemedComponent.ts
@@ -1,3 +1,0 @@
-export interface IThemedComponent {
-  primaryColor?: string;
-}

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -1,5 +1,4 @@
 import type { $$StyledComponentProps } from '@voiceflow/stitches-react/types/styled-component';
-export * from './IThemedComponent';
 export * from './session';
 export * from './trace';
 export * from './turn';


### PR DESCRIPTION
Removed `IThemedComponent` - components shouldn't be aware of the 'theme' of the chat widget.  
They all rely on variables, that should be defined on the outer most wrapper of the Chat Widget.

Added a decorator called `WithPalette` to wrap stories, and this defines all the `inlineVars` with the default palette.  
Created a hook called `usePalette` - similar to `useTheme` but will get the whole palette defined from the `AssistantInfo` object (which is defined by the user)
