### PR TITLE
fix: show Prompt over scroll down button (COR-3947)

### DIFF
--- a/packages/chat/src/components/Prompt/styles.css.ts
+++ b/packages/chat/src/components/Prompt/styles.css.ts
@@ -19,7 +19,7 @@ export const promptContainer = recipe({
     display: 'flex',
     flexDirection: 'column',
     gap: 8,
-    zIndex: 3,
+    zIndex: 300,
   },
 
   variants: {
@@ -51,7 +51,7 @@ export const chatOverlay = recipe({
       true: {
         display: 'block',
         opacity: 1,
-        zIndex: 2,
+        zIndex: 200,
         pointerEvents: 'auto',
       },
     },


### PR DESCRIPTION
Adjust zIndex of relevant components so the scroll button doesn't appear over the Prompt Component