### PR TITLE
fix: move feedback buttons with carousel (COR-4091)

### DIFF
--- a/packages/chat/src/components/Carousel/index.tsx
+++ b/packages/chat/src/components/Carousel/index.tsx
@@ -8,7 +8,7 @@ import { Avatar } from '../Avatar';
 import { Card } from '../Card';
 import { CARD_WIDTH } from '../Card/styles.css';
 import type { CardProps } from '../Card/types';
-import { hide, responseAvatar } from '../SystemResponse/styles.css';
+import { feedbackContainer, hide, responseAvatar } from '../SystemResponse/styles.css';
 import { CarouselButton } from './CarouselButton';
 import { useScrollObserver, useScrollTo } from './hooks';
 import {
@@ -19,6 +19,8 @@ import {
   GUTTER_WIDTH,
   lastCardSpacer,
 } from './styles.css';
+import { FeedbackButton } from '../FeedbackButton';
+import { FeedbackButtonVariant, IFeedbackButton } from '../FeedbackButton/FeedbackButton.interface';
 
 const CARD_WITH_GUTTER = CARD_WIDTH + GUTTER_WIDTH;
 
@@ -37,6 +39,12 @@ export interface CarouselProps {
    * If true, renders an avatar next to the message.
    */
   withImage: boolean;
+
+  /**
+   * If provided, will display {@link FeedbackButton} component.
+   * @default false
+   */
+  feedback?: IFeedbackButton | undefined;
 }
 
 /**
@@ -44,7 +52,7 @@ export interface CarouselProps {
  *
  * @see {@link https://voiceflow.github.io/react-chat/?path=/story/components-carousel--single-card}
  */
-export const Carousel: React.FC<CarouselProps> = ({ cards, avatar, withImage }) => {
+export const Carousel: React.FC<CarouselProps> = ({ cards, avatar, withImage, feedback }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { showPreviousButton, showNextButton } = useScrollObserver(scrollContainerRef, cards);
   const scrollToPrevious = useScrollTo(scrollContainerRef, (el) => Math.ceil(el.scrollLeft / CARD_WITH_GUTTER) - 1);
@@ -68,6 +76,11 @@ export const Carousel: React.FC<CarouselProps> = ({ cards, avatar, withImage }) 
           ))}
           <div className={lastCardSpacer}> </div>
         </div>
+        {feedback && (
+          <div className={feedbackContainer}>
+            <FeedbackButton {...feedback} variant={FeedbackButtonVariant.LAST_RESPONSE} />
+          </div>
+        )}
       </div>
       <CarouselButton direction="left" visible={showPreviousButton} onClick={scrollToPrevious} />
       <CarouselButton direction="right" visible={showNextButton} onClick={scrollToNext} />

--- a/packages/chat/src/components/Carousel/index.tsx
+++ b/packages/chat/src/components/Carousel/index.tsx
@@ -8,6 +8,8 @@ import { Avatar } from '../Avatar';
 import { Card } from '../Card';
 import { CARD_WIDTH } from '../Card/styles.css';
 import type { CardProps } from '../Card/types';
+import { FeedbackButton } from '../FeedbackButton';
+import { FeedbackButtonVariant, type IFeedbackButton } from '../FeedbackButton/FeedbackButton.interface';
 import { feedbackContainer, hide, responseAvatar } from '../SystemResponse/styles.css';
 import { CarouselButton } from './CarouselButton';
 import { useScrollObserver, useScrollTo } from './hooks';
@@ -19,8 +21,6 @@ import {
   GUTTER_WIDTH,
   lastCardSpacer,
 } from './styles.css';
-import { FeedbackButton } from '../FeedbackButton';
-import { FeedbackButtonVariant, IFeedbackButton } from '../FeedbackButton/FeedbackButton.interface';
 
 const CARD_WITH_GUTTER = CARD_WIDTH + GUTTER_WIDTH;
 

--- a/packages/chat/src/components/SystemResponse/SystemMessage.tsx
+++ b/packages/chat/src/components/SystemResponse/SystemMessage.tsx
@@ -75,7 +75,7 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
         // We check for `MessageType.CAROUSEL` before all the others, because a Carousel will take care
         // of rendering the Avatar itself
         .with({ type: MessageType.CAROUSEL }, (props) => (
-          <Carousel {...{ avatar, withImage, ...R.omit(props, ['type']) }} />
+          <Carousel {...{ avatar, withImage, feedback, ...R.omit(props, ['type']) }} />
         ))
         .otherwise((message) => (
           <>

--- a/packages/chat/src/components/SystemResponse/index.tsx
+++ b/packages/chat/src/components/SystemResponse/index.tsx
@@ -114,7 +114,12 @@ export const SystemResponse: React.FC<SystemResponseProps> = ({
         }
 
         const lastMessageInGroup = index === visibleMessages.length - 1;
+
+        // Showing feedback on previous messages that were in the chat
         const showFeedback = lastMessageInGroup && message.type === MessageType.TEXT;
+
+        // Showing feedback on the most recent system message of the chat
+        const addFeedback = feedback && isLast && complete && lastMessageInGroup;
 
         return (
           <>
@@ -124,11 +129,11 @@ export const SystemResponse: React.FC<SystemResponseProps> = ({
               avatar={avatar}
               timestamp={timestamp}
               isLast={isLast}
-              feedback={showFeedback ? feedback : undefined}
+              feedback={showFeedback || (addFeedback && message.type === MessageType.CAROUSEL) ? feedback : undefined}
               textContent={allTextContentForMessage}
               key={index}
             />
-            {feedback && isLast && complete && lastMessageInGroup && (
+            {addFeedback && message.type !== MessageType.CAROUSEL && (
               <div className={feedbackContainer}>
                 <FeedbackButton
                   {...feedback}


### PR DESCRIPTION
If the last message was a carousel, then we render the `FeedbackButtons` component inside the `Carousel` component, because we want it to scroll with it.