### PR TITLE
fix: embedded view is always open (COR-0000)

### DIFF
--- a/packages/chat/src/components/NewChat/ChatContainer/ChatContainer.component.tsx
+++ b/packages/chat/src/components/NewChat/ChatContainer/ChatContainer.component.tsx
@@ -1,18 +1,24 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import type { WidgetSettingsColorPalette } from '@voiceflow/dtos-interact';
+import clsx from 'clsx';
 
 import { PALETTE } from '@/styles/colors.css';
+import { chatIsOpen } from '@/views/ChatWidget/styles.css';
 
 import { chatWindowStyle } from './ChatContainer.css';
 
 export interface IChatContainer {
   palette: WidgetSettingsColorPalette;
   children?: React.ReactNode;
+  embedded?: boolean;
 }
 
-export const ChatContainer: React.FC<IChatContainer> = ({ palette, children }) => {
+export const ChatContainer: React.FC<IChatContainer> = ({ palette, children, embedded }) => {
   return (
-    <div style={assignInlineVars(PALETTE, { colors: palette })} className={chatWindowStyle}>
+    <div
+      style={assignInlineVars(PALETTE, { colors: palette })}
+      className={clsx(chatWindowStyle, embedded ? chatIsOpen : '')}
+    >
       {children}
     </div>
   );

--- a/packages/chat/src/views/ChatWindow/index.tsx
+++ b/packages/chat/src/views/ChatWindow/index.tsx
@@ -12,8 +12,8 @@ import { UserResponse } from '@/components/UserResponse';
 import { RuntimeStateAPIContext, RuntimeStateContext } from '@/contexts/RuntimeContext';
 import type { FeedbackName } from '@/contexts/RuntimeContext/useRuntimeAPI';
 import { DEFAULT_CHAT_AVATAR } from '@/dtos/AssistantOptions.dto';
+import { RenderMode } from '@/dtos/RenderOptions.dto';
 import { usePalette } from '@/hooks/usePalette';
-import { RenderMode } from '@/main';
 import type { UserTurnProps } from '@/types';
 import { SessionStatus, TurnType } from '@/types';
 

--- a/packages/chat/src/views/ChatWindow/index.tsx
+++ b/packages/chat/src/views/ChatWindow/index.tsx
@@ -13,6 +13,7 @@ import { RuntimeStateAPIContext, RuntimeStateContext } from '@/contexts/RuntimeC
 import type { FeedbackName } from '@/contexts/RuntimeContext/useRuntimeAPI';
 import { DEFAULT_CHAT_AVATAR } from '@/dtos/AssistantOptions.dto';
 import { usePalette } from '@/hooks/usePalette';
+import { RenderMode } from '@/main';
 import type { UserTurnProps } from '@/types';
 import { SessionStatus, TurnType } from '@/types';
 
@@ -50,7 +51,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ isMobile }) => {
   const hasEnded = runtime.isStatus(SessionStatus.ENDED);
 
   return (
-    <NewChat.Container palette={palette}>
+    <NewChat.Container embedded={config.render.mode === RenderMode.EMBEDDED} palette={palette}>
       <NewChat
         headerProps={{
           title: assistant.chat.banner.title,


### PR DESCRIPTION
When using `RenderMode.EMBEDDED` then we pass the class `chatIsOpen` to the container, because it is always displayed in it's 'open' state.