### PR TITLE
fix: carousel hitbox edges fix (COR-4364)

### DIFF
--- a/apps/documentation/src/components/ChatScript/index.tsx
+++ b/apps/documentation/src/components/ChatScript/index.tsx
@@ -15,7 +15,8 @@ export const ChatScript = ({ projectID, embedded = false }: { projectID: string;
           verify: { projectID: "${projectID}"  },
             assistant: {
             stylesheet: '../../bundle/style.css',
-          }
+          },
+          versionID: 'production'
           ${embedded ? ', render: { mode: "embedded", target: document.getElementById("chat_embed") }' : ''}
         });
       };

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -75,7 +75,7 @@
     "test:unit": "yarn g:vitest run --coverage"
   },
   "dependencies": {
-    "@vanilla-extract/css": "1.15.5",
+    "@vanilla-extract/css": "1.16.1",
     "@vanilla-extract/recipes": "0.5.5",
     "@voiceflow/base-types": "2.113.1",
     "@voiceflow/dtos-interact": "1.10.0",
@@ -123,7 +123,7 @@
     "@types/react-speech-recognition": "^3.9.5",
     "@types/react-syntax-highlighter": "15.5.13",
     "@vanilla-extract/dynamic": "2.1.2",
-    "@vanilla-extract/vite-plugin": "4.0.15",
+    "@vanilla-extract/vite-plugin": "4.0.18",
     "@vitejs/plugin-react": "4.2.1",
     "@voiceflow/test-common": "1.10.3",
     "chromatic": "11.2.0",

--- a/packages/chat/src/components/Carousel/Carousel.story.tsx
+++ b/packages/chat/src/components/Carousel/Carousel.story.tsx
@@ -5,6 +5,7 @@ import { RuntimeProvider } from '@/contexts';
 import { MOCK_IMAGE } from '@/fixtures';
 import { DEFAULT_AVATAR, RenderMode } from '@/main';
 import { WithDefaultPalette } from '@/storybook/decorators';
+import { widgetContainer } from '@/views/ChatWidget/styles.css';
 
 import { NewChat } from '../NewChat';
 import { MessageType } from '../SystemResponse/constants';
@@ -30,7 +31,32 @@ const meta: Meta<typeof Carousel> = {
           ...DEFAULT_WIDGET_SETTINGS,
         }}
       >
-        {Story()}
+        <div style={{ width: '380px' }} className={widgetContainer.classNames.variants.withChat.true}>
+          <NewChat
+            welcomeMessageProps={{
+              enabled: true,
+              title: 'Your awesome assistant',
+              description: 'Im hot, youre not, deal with it',
+            }}
+            headerProps={{
+              showImage: true,
+              title: 'Your awesome assistant',
+            }}
+            footerProps={{
+              showPoweredBy: true,
+              extraLinkText: 'Privacy',
+              extraLinkUrl: 'https://voiceflow.com',
+              messageInputProps: {
+                onSubmit: async (_) => Promise.resolve(),
+                placeholder: 'Message...',
+              },
+            }}
+            isLoading={false}
+            hasEnded={false}
+          >
+            {Story()}
+          </NewChat>
+        </div>
       </RuntimeProvider>
     ),
     WithDefaultPalette,
@@ -72,64 +98,69 @@ const MULTIPLE_CARDS = [
 
 export const Default: Story = {
   render: () => (
-    <div style={{ width: '380px' }}>
-      <NewChat
-        welcomeMessageProps={{
-          enabled: true,
-          title: 'Your awesome assistant',
-          description: 'Im hot, youre not, deal with it',
+    <>
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.CAROUSEL,
+          cards: MULTIPLE_CARDS,
         }}
-        headerProps={{
-          showImage: true,
-          title: 'Your awesome assistant',
+        withImage={false}
+      />
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.TEXT,
+          text: 'Do you like this carousel ?',
         }}
-        footerProps={{
-          showPoweredBy: true,
-          extraLinkText: 'Privacy',
-          extraLinkUrl: 'https://voiceflow.com',
-          messageInputProps: {
-            onSubmit: async (_) => Promise.resolve(),
-            placeholder: 'Message...',
-          },
-        }}
-        isLoading={false}
-        hasEnded={false}
-      >
-        <SystemMessage
-          avatar={DEFAULT_AVATAR}
-          message={{
-            type: MessageType.CAROUSEL,
-            cards: MULTIPLE_CARDS,
-          }}
-          withImage={false}
-        />
-        <SystemMessage
-          avatar={DEFAULT_AVATAR}
-          message={{
-            type: MessageType.TEXT,
-            text: 'Do you like this carousel ?',
-          }}
-          withImage={true}
-        />
-      </NewChat>
-    </div>
+        withImage={true}
+      />
+    </>
   ),
 };
 
 export const SingleCard: Story = {
-  args: {
-    cards: [FIRST_CARD],
-  },
+  render: () => (
+    <>
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.CAROUSEL,
+          cards: [FIRST_CARD],
+        }}
+        withImage={false}
+      />
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.TEXT,
+          text: 'Do you like this carousel ?',
+        }}
+        withImage={true}
+      />
+    </>
+  ),
 };
 
 export const MultipleCards: Story = {
-  args: {
-    cards: MULTIPLE_CARDS,
-  },
-};
-
-export const WithControls: Story = {
-  args: {
-    cards: MULTIPLE_CARDS,
-  },
+  render: () => (
+    <>
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.CAROUSEL,
+          cards: MULTIPLE_CARDS,
+        }}
+        withImage={false}
+      />
+      <SystemMessage
+        avatar={DEFAULT_AVATAR}
+        message={{
+          type: MessageType.TEXT,
+          text: 'Do you like this carousel ?',
+        }}
+        withImage={true}
+      />
+    </>
+  ),
 };

--- a/packages/chat/src/components/Carousel/CarouselButton.tsx
+++ b/packages/chat/src/components/Carousel/CarouselButton.tsx
@@ -1,9 +1,11 @@
+import clsx from 'clsx';
 import type { MouseEventHandler } from 'react';
 import { forwardRef } from 'react';
 
 import { Icon } from '@/components/Icon';
 
-import { carouselButton, rotate180 } from './carouselButtonStyles.css';
+import { buttonReset } from '../Button/reset.css';
+import { buttonWrapper, carouselButton, rotate180 } from './carouselButtonStyles.css';
 
 export interface CarouselButtonProps {
   /**
@@ -33,8 +35,14 @@ export interface CarouselButtonProps {
  */
 export const CarouselButton = forwardRef<HTMLButtonElement, CarouselButtonProps>(
   ({ onClick, visible, direction, noAvatar }, ref) => (
-    <button ref={ref} className={carouselButton({ visible, direction, withAvatar: !noAvatar })} onClick={onClick}>
-      <Icon svg="arrowRight" className={direction === 'left' ? rotate180 : ''} />
+    <button
+      ref={ref}
+      className={clsx(buttonReset, buttonWrapper({ direction, visible, withAvatar: !noAvatar }))}
+      onClick={onClick}
+    >
+      <div className={carouselButton()}>
+        <Icon svg="arrowRight" className={direction === 'left' ? rotate180 : ''} />
+      </div>
     </button>
   )
 );

--- a/packages/chat/src/components/Carousel/carouselButtonStyles.css.ts
+++ b/packages/chat/src/components/Carousel/carouselButtonStyles.css.ts
@@ -55,46 +55,17 @@ const fadeOutToRight = keyframes({
   },
 });
 
-export const carouselButton = recipe({
-  base: [
-    buttonStyles({ round: true }),
-    {
-      height: BUTTON_SIZE,
-      width: BUTTON_SIZE,
-      color: COLORS.NEUTRAL_DARK[100],
-      border: `solid 1px ${COLORS.NEUTRAL_LIGHT[100]}`,
-      backgroundColor: COLORS.white,
-      boxShadow: '0px 3px 4px 0px rgba(0, 0, 0, 0.02), 0px 8px 42px -16px rgba(0, 0, 0, 0.06)',
-      transition: transition(['opacity', 'color', 'transform']),
-      ':hover': {
-        color: COLORS.NEUTRAL_DARK[600],
-        transform: 'scale(1.15)',
-      },
-      ':active': {
-        color: COLORS.NEUTRAL_DARK[800],
-        transform: 'scale(0.8)',
-      },
-
-      // When the buttons are inside a carousel
-      [`.${carouselContainer} &`]: {
-        position: 'absolute',
-        top: '64px',
-      },
-    },
-  ],
+export const buttonWrapper = recipe({
+  base: {
+    backgroundColor: 'transparent',
+    height: BUTTON_SIZE + 6,
+    width: BUTTON_SIZE + 6,
+    padding: 2,
+    position: 'absolute',
+    top: '64px',
+  },
 
   variants: {
-    visible: {
-      true: {
-        opacity: 1,
-        pointerEvents: 'auto',
-      },
-      false: {
-        opacity: 0,
-        pointerEvents: 'none',
-      },
-    },
-
     direction: {
       right: {
         [`.${carouselContainer} &`]: {
@@ -107,11 +78,20 @@ export const carouselButton = recipe({
         },
       },
     },
+    visible: {
+      true: {
+        opacity: 1,
+        pointerEvents: 'auto',
+      },
+      false: {
+        opacity: 0,
+        pointerEvents: 'none',
+      },
+    },
     withAvatar: {
       false: {},
     },
   },
-
   compoundVariants: [
     {
       variants: {
@@ -174,6 +154,28 @@ export const carouselButton = recipe({
       style: {
         opacity: 0,
         animation: `${fadeOutToRight} .15s ease-in`,
+      },
+    },
+  ],
+});
+
+export const carouselButton = recipe({
+  base: [
+    buttonStyles({ round: true }),
+    {
+      borderRadius: '50%',
+      color: COLORS.NEUTRAL_DARK[100],
+      border: `solid 1px ${COLORS.NEUTRAL_LIGHT[100]}`,
+      backgroundColor: COLORS.white,
+      boxShadow: '0px 3px 4px 0px rgba(0, 0, 0, 0.02), 0px 8px 42px -16px rgba(0, 0, 0, 0.06)',
+      transition: transition(['opacity', 'color', 'transform']),
+      ':hover': {
+        color: COLORS.NEUTRAL_DARK[600],
+        transform: 'scale(1.15)',
+      },
+      ':active': {
+        color: COLORS.NEUTRAL_DARK[800],
+        transform: 'scale(0.8)',
       },
     },
   ],

--- a/packages/chat/src/components/Carousel/index.tsx
+++ b/packages/chat/src/components/Carousel/index.tsx
@@ -18,6 +18,7 @@ import {
   cardsContainer,
   cardsInnerContainer,
   carouselContainer,
+  firstCard,
   GUTTER_WIDTH,
   lastCardSpacer,
 } from './styles.css';
@@ -65,7 +66,7 @@ export const Carousel: React.FC<CarouselProps> = ({ cards, avatar, withImage, fe
           {avatar && <Avatar avatar={avatar} className={clsx(withImage ? '' : hide, responseAvatar, avatarStyle)} />}
           {cards.map((card, i) => (
             <div
-              className={fadeInAndUp}
+              className={clsx(fadeInAndUp, i === 0 ? firstCard : '')}
               key={i}
               style={{
                 animationDelay: `${i * 0.1}s`,

--- a/packages/chat/src/components/Carousel/styles.css.ts
+++ b/packages/chat/src/components/Carousel/styles.css.ts
@@ -19,6 +19,10 @@ export const cardsContainer = style({
   paddingRight: `${DIALOG_PADDING}px`,
 });
 
+export const firstCard = style({
+  marginLeft: 2,
+});
+
 export const cardsInnerContainer = style({
   display: 'flex',
   alignItems: 'start',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7045,15 +7045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/babel-plugin-debug-ids@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@vanilla-extract/babel-plugin-debug-ids@npm:1.0.6"
-  dependencies:
-    "@babel/core": ^7.23.9
-  checksum: 55f173c0c6a95a8da35a8625e6400dd90a126a4cd3d52d6a5583573e957c0f13c408fd86873d1d65ac1cfa9dfd743306ed866ad8ed1793370b3857e0636b88df
-  languageName: node
-  linkType: hard
-
 "@vanilla-extract/babel-plugin-debug-ids@npm:^1.1.0":
   version: 1.1.0
   resolution: "@vanilla-extract/babel-plugin-debug-ids@npm:1.1.0"
@@ -7063,9 +7054,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/css@npm:1.15.5, @vanilla-extract/css@npm:^1.15.5":
-  version: 1.15.5
-  resolution: "@vanilla-extract/css@npm:1.15.5"
+"@vanilla-extract/css@npm:1.16.1, @vanilla-extract/css@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@vanilla-extract/css@npm:1.16.1"
   dependencies:
     "@emotion/hash": ^0.9.0
     "@vanilla-extract/private": ^1.0.6
@@ -7079,7 +7070,7 @@ __metadata:
     media-query-parser: ^2.0.2
     modern-ahocorasick: ^1.0.0
     picocolors: ^1.0.0
-  checksum: 0c260e55a1648a827df74cae4475a1a61767e4ef3a7a3a299853ae3f77ed220d7a4b604737886140ea9e72a379eda4ee45b7349a4651cf3d5a4f2c8697448d6d
+  checksum: ff58f32778cbc15458aff951ad771ba46f772d78633ff99f849f590b83a22ce67e017af28351c68c32edcdaae4454146dd90f369842a627ee79dc9c3ab434e1e
   languageName: node
   linkType: hard
 
@@ -7132,14 +7123,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/integration@npm:^7.1.9":
-  version: 7.1.9
-  resolution: "@vanilla-extract/integration@npm:7.1.9"
+"@vanilla-extract/integration@npm:^7.1.11":
+  version: 7.1.11
+  resolution: "@vanilla-extract/integration@npm:7.1.11"
   dependencies:
     "@babel/core": ^7.23.9
     "@babel/plugin-syntax-typescript": ^7.23.3
-    "@vanilla-extract/babel-plugin-debug-ids": ^1.0.6
-    "@vanilla-extract/css": ^1.15.5
+    "@vanilla-extract/babel-plugin-debug-ids": ^1.1.0
+    "@vanilla-extract/css": ^1.16.1
     dedent: ^1.5.3
     esbuild: "npm:esbuild@>=0.17.6 <0.24.0"
     eval: 0.1.8
@@ -7148,7 +7139,7 @@ __metadata:
     mlly: ^1.4.2
     vite: ^5.0.11
     vite-node: ^1.2.0
-  checksum: 6f6b1eab9f67091c47c070cdf8128034458f7cc649a3188037b85f7cd466466405b91321e3d909b8a5b81452280bc885a4c08530ab8bad20d6c22b5e69ec4602
+  checksum: 23196f388045c0cdaa35bf26cf484ca4423e336026770b743017056aed7704c74c2134b425571eee9c6859ed1a1553a435e4d0c502ff5a78f8dc2c02db00707a
   languageName: node
   linkType: hard
 
@@ -7179,14 +7170,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/vite-plugin@npm:4.0.15":
-  version: 4.0.15
-  resolution: "@vanilla-extract/vite-plugin@npm:4.0.15"
+"@vanilla-extract/vite-plugin@npm:4.0.18":
+  version: 4.0.18
+  resolution: "@vanilla-extract/vite-plugin@npm:4.0.18"
   dependencies:
-    "@vanilla-extract/integration": ^7.1.9
+    "@vanilla-extract/integration": ^7.1.11
   peerDependencies:
     vite: ^4.0.3 || ^5.0.0
-  checksum: b99f1bb339ea5bdb12129f7689dba01506329bc9a3234d25db7da599e58b98a3380abb3cbcfa18a891630f275c5129209bc0dc655c24502303c9ed9e4a4efa99
+  checksum: 99f816370e93153a77be9882206eda948626305bd7d18d7121f849024ab194266b7ae0823f2f2f69a7cfb76e027b21d0a6c99f02c56aa495b04993fd9aa9816d
   languageName: node
   linkType: hard
 
@@ -7654,10 +7645,10 @@ __metadata:
     "@types/react-dom": 18.2.4
     "@types/react-speech-recognition": ^3.9.5
     "@types/react-syntax-highlighter": 15.5.13
-    "@vanilla-extract/css": 1.15.5
+    "@vanilla-extract/css": 1.16.1
     "@vanilla-extract/dynamic": 2.1.2
     "@vanilla-extract/recipes": 0.5.5
-    "@vanilla-extract/vite-plugin": 4.0.15
+    "@vanilla-extract/vite-plugin": 4.0.18
     "@vitejs/plugin-react": 4.2.1
     "@voiceflow/base-types": 2.113.1
     "@voiceflow/dtos-interact": 1.10.0


### PR DESCRIPTION
**Fixes or implements VF-4364**

### Brief description. What is this change?

Fixed the carousel button hitbox issue by making the 'surrounding' button component a little bit bigger so when the image is enlarged it will still be inside of the 'hitbox'.

Added the `NewChat` component wrapper to the Carousel story, so that it looks good in storybook.
Added a `2px` left margin to the first carousel card to align it with the other messages displayed above or below it.

Also updated `@vanilla-extract/css` and `@vanilla-extract/vite` packages.  
Initially did this cause I thought there was a vanilla-extract related bug - there wasn't, but the update is still helpful to stay updated.